### PR TITLE
Документировать Navigation as State и roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,56 +1,97 @@
-name: Bug report
-description: Report reproducible incorrect behavior or a crash
-title: "[Bug]: "
+name: Сообщение о баге
+description: Сообщить о воспроизводимом неверном поведении или crash
+title: "[Баг]: "
 labels:
   - bug
 body:
   - type: markdown
     attributes:
-      value: Thanks for helping improve udf-sandbox. Please remove sensitive data from logs and screenshots.
+      value: Перед публикацией удалите tokens, персональные данные и другие секреты из logs и screenshots.
 
   - type: textarea
     id: summary
     attributes:
-      label: Summary
-      description: What went wrong?
+      label: Краткое описание
+      description: Что работает неправильно?
     validations:
       required: true
 
   - type: textarea
     id: steps
     attributes:
-      label: Steps to reproduce
+      label: Шаги воспроизведения
       placeholder: |
-        1. Open ...
-        2. Tap ...
-        3. Observe ...
+        1. Открыть ...
+        2. Нажать ...
+        3. Наблюдать ...
     validations:
       required: true
 
   - type: textarea
+    id: nav_state
+    attributes:
+      label: Navigation state до и после
+      description: Если баг связан с навигацией, укажите логический stack и action.
+      placeholder: |
+        Action: swipe-to-dismiss Account(42)
+        До: Home -> Accounts -> Account(42)
+        Ожидалось после: Home -> Accounts
+        Фактически после: Home -> Accounts -> Account(42)
+
+  - type: textarea
     id: expected
     attributes:
-      label: Expected behavior
+      label: Ожидаемое поведение
     validations:
       required: true
 
   - type: textarea
     id: actual
     attributes:
-      label: Actual behavior
+      label: Фактическое поведение
     validations:
       required: true
 
   - type: input
     id: environment
     attributes:
-      label: Device and Android version
+      label: Устройство и версия Android
       placeholder: Pixel 7 Pro emulator, Android 14 / API 34
     validations:
       required: true
 
+  - type: dropdown
+    id: layout
+    attributes:
+      label: Конфигурация окна
+      options:
+        - Single-pane
+        - Multi-pane
+        - Обе
+        - Не применимо
+    validations:
+      required: true
+
+  - type: dropdown
+    id: orientation
+    attributes:
+      label: Ориентация
+      options:
+        - Portrait
+        - Landscape
+        - Обе
+        - Не применимо
+    validations:
+      required: true
+
+  - type: textarea
+    id: lifecycle
+    attributes:
+      label: Lifecycle и способ ввода
+      description: Укажите rotation, Activity recreation, process recreation, Android Back, swipe, scrim tap или быстрые повторные события, если это важно.
+
   - type: textarea
     id: evidence
     attributes:
-      label: Logs, screenshots, or recording
-      description: Drag files here. Remove tokens, personal data, and other secrets first.
+      label: Logs, screenshots или запись
+      description: Перетащите файлы сюда. Сначала удалите tokens, персональные данные и другие секреты.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,34 +1,77 @@
-name: Feature or experiment
-description: Propose a UDF, navigation, state, or UI experiment
-title: "[Idea]: "
+name: Фича или эксперимент
+description: Предложить эксперимент с UDF, navigation state, projection или Compose UI
+title: "[Идея]: "
 labels:
   - enhancement
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Сохраняйте эксперимент сфокусированным. Укажите зависимость в roadmap, опишите проверяемый state transition или projection и сформулируйте наблюдаемый результат.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Контекст
+      description: Что должен знать Android-разработчик без контекста проекта, чтобы оценить предложение?
+    validations:
+      required: true
+
   - type: textarea
     id: problem
     attributes:
-      label: Problem or question
-      description: What should this experiment help us learn or solve?
+      label: Проблема или вопрос
+      description: Что этот эксперимент должен помочь понять или исправить?
     validations:
       required: true
 
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed approach
-      description: Describe the state, events, effects, navigation, and UI involved.
+      label: Предлагаемый подход
+      description: Опишите затронутые state, actions, effects, navigation и UI.
     validations:
       required: true
 
   - type: textarea
+    id: state_example
+    attributes:
+      label: Пример state или projection
+      description: Покажите action, state до и после, а также compact/expanded projection, если это применимо.
+      placeholder: |
+        Action: Back
+        До: Home -> Accounts -> Account(42)
+        После: Home -> Accounts
+        Single-pane UI: Accounts
+        Multi-pane UI: Home с Accounts в дочернем слоте
+
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Затронутые инварианты
+      description: Какие правила из docs/PROJECT_CONTEXT.md должны остаться истинными?
+
+  - type: textarea
     id: success
     attributes:
-      label: Success criteria
-      description: What observable behavior or test would demonstrate success?
+      label: Критерии успеха
+      description: Какое наблюдаемое поведение или тест докажет успех?
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives and trade-offs
+      label: Альтернативы и trade-offs
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Вне scope
+      description: Какая связанная работа намеренно исключена из этой issue?
+
+  - type: input
+    id: dependencies
+    attributes:
+      label: Зависимости
+      description: Укажите blocking или prerequisite issues либо напишите "Нет".

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,25 @@
-## Why
+## Зачем
 
-<!-- What problem or experiment does this change address? -->
+<!-- Какую проблему или гипотезу проверяет изменение? -->
 
-## What changed
+Closes #<!-- номер issue -->
 
-<!-- Describe state, event, effect, navigation, and UI changes where relevant. -->
+## Что изменилось
 
-## Verification
+<!-- Опишите изменения state, actions, effects, navigation и UI. -->
+
+## Проверка
 
 - [ ] `./gradlew testDebugUnitTest lintDebug assembleDebug`
-- [ ] I added or updated tests for behavior changes
-- [ ] I checked state restoration and navigation/back behavior
-- [ ] I attached screenshots or a short recording for UI changes
+- [ ] Я добавил или обновил тесты для изменённого поведения либо отметил N/A
+- [ ] Я проверил state restoration и navigation/Back behavior либо отметил N/A
+- [ ] Я приложил screenshots или короткую запись для UI-изменений либо отметил N/A
+- [ ] Я сохранил или осознанно обновил инварианты из `docs/PROJECT_CONTEXT.md` либо отметил N/A
 
-## Notes
+## Пример state и projection
 
-<!-- Follow-ups, trade-offs, or known limitations. -->
+<!-- Для navigation-изменений покажите action, state до/после и compact/expanded projection. -->
+
+## Примечания
+
+<!-- Оставшиеся trade-offs, follow-up issues или известные ограничения. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,71 @@
-# Repository guidelines
+# Правила работы с репозиторием
 
-## Project
+## Что прочитать сначала
 
-`udf-sandbox` is a single-module Android application for experiments with Kotlin, Jetpack Compose, navigation, and unidirectional data flow.
+Перед изменением навигации или state handling прочитайте:
 
-## Development
+1. [`README.md`](README.md) — вопрос, который исследует проект, и его текущее устройство.
+2. [`docs/PROJECT_CONTEXT.md`](docs/PROJECT_CONTEXT.md) — устойчивый архитектурный контекст, инварианты, риски и целевое направление.
+3. [Roadmap](https://github.com/senneco/udf-sandbox/issues/7) и выбранную дочернюю задачу.
 
-- Use JDK 17 and the committed Gradle wrapper.
-- Keep experiments small and avoid unrelated dependency or formatting churn.
-- Run `./gradlew testDebugUnitTest lintDebug assembleDebug` before submitting changes.
-- Add tests for changed state transitions, navigation, and user-visible behavior.
-- Never commit signing keys, tokens, credentials, `local.properties`, or generated build output.
+GitHub Issues — единственный источник истины для scope и статуса задач. Не создавайте второй checklist в документации репозитория.
 
-## Code Review Rules
+## Цель проекта
 
-- Prioritize crashes, invalid state transitions, lost state after recreation, and broken back/navigation behavior.
-- Check that asynchronous effects cannot update stale state or run more than once unintentionally.
-- Treat unsafe null assertions, exact floating-point comparisons, and release-only logging or backup behavior as risks when they affect the changed code.
-- Require evidence for behavior changes: focused tests plus screenshots or a short recording for UI changes.
-- Flag dependency changes that update only one incompatible part of the Gradle, Android Gradle Plugin, Kotlin, or Compose toolchain.
+`udf-sandbox` — одномодульный Android-эксперимент. Его главный вопрос: можно ли представить навигацию как сериализуемое состояние приложения и рендерить её как детерминированную Compose-проекцию.
+
+Банковские экраны — только demo fixtures, а не продуктовый domain. Предпочитайте изменения, которые помогают проверить navigation hypothesis, а не развивают несвязанную функциональность приложения.
+
+## Архитектурное направление
+
+- UI отправляет типизированные actions и не изменяет глобальный state напрямую.
+- Единственный lifecycle-aware store владеет `AppState` и применяет переходы через чистый reducer.
+- Navigation history использует стабильную идентичность `BackStackEntry`, отделённую от данных route.
+- Чистая проекция преобразует navigation state и конфигурацию окна в root-, nested- и modal-слоты.
+- Compose рендерит проекцию и сообщает о UI-only событиях, например о завершении dismiss-анимации.
+- Долгоживущий navigation state не содержит временный прогресс анимации.
+- Root entry остаётся валидным после любого перехода, включая быстрые повторные события.
+- Navigation state и entry identity сериализуются для восстановления после process death.
+
+Использование AndroidX Navigation не запрещено, но внутренний back stack `NavController` не должен незаметно становиться каноническим state. Любая интеграция обязана сохранить детерминированное владение state и semantics восстановления.
+
+## Legacy baseline
+
+Текущий прототип появился раньше целевой архитектуры:
+
+- `UdfApp.appState` глобален и напрямую изменяется из нескольких composables;
+- `AnimatedNavigation` совмещает проекцию, рендеринг, выбор анимации, modal diff и мутацию state;
+- инварианты destination и root stack не зафиксированы в модели;
+- restoration и поведенческие тесты отсутствуют.
+
+Считайте это ограничениями миграции, а не примерами для нового кода. Делайте изменения поведения явно и не начинайте большой rewrite без characterization tests.
+
+## Разработка
+
+- Используйте JDK 17 и Gradle Wrapper из репозитория.
+- Работайте из GitHub issue с явным контекстом и acceptance criteria.
+- Сохраняйте изменения небольшими; не смешивайте behavior refactoring с обновлением зависимостей или форматированием.
+- Предпочитайте чистый Kotlin для reducers, navigation models, projection и тестов.
+- Оставляйте Android- и Compose-зависимости на границах рендеринга и lifecycle.
+- Добавляйте тесты для каждого изменённого state transition, projection rule, restoration path и Back behavior.
+- Для UI-изменений прикладывайте скриншот или короткую запись для затронутой конфигурации окна.
+- Не коммитьте signing keys, tokens, credentials, `local.properties` и generated build output.
+
+Перед отправкой изменений выполните:
+
+```bash
+./gradlew testDebugUnitTest lintDebug assembleDebug
+```
+
+## Приоритеты code review
+
+Проверяйте в таком порядке:
+
+1. crashes и невалидный или пустой navigation stack;
+2. неверные semantics push, pop, replace, dismiss или Android Back;
+3. потерю или дублирование state после recreation, process death или изменения layout;
+4. устаревшие asynchronous callbacks и анимации, изменяющие уже новый entry;
+5. несовместимую entry identity или Compose keys;
+6. отсутствие сфокусированных тестов и UI evidence.
+
+Считайте рискованными `!!`, точные сравнения `Float`, мутацию state во время composition и частичное обновление связки Android Gradle Plugin / Gradle / Kotlin / Compose, если они затрагивают изменяемый код.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,23 @@
-# Contributing
+# Участие в разработке
 
-This repository is a small Android sandbox for exploring unidirectional data flow (UDF), navigation, and Compose UI behavior. Keep changes focused and explain what the experiment is intended to demonstrate.
+`udf-sandbox` — сфокусированный Android-эксперимент о навигации как состоянии приложения. Перед предложением архитектурных изменений прочитайте [README.md](README.md) и [контекст проекта](docs/PROJECT_CONTEXT.md).
 
-## Local setup
+## Выбор задачи
 
-Install Android Studio with the Android SDK, JDK 17, and an Android emulator or device. The project pins its Gradle version through the wrapper and its Java major version in `.java-version`.
+GitHub Issues — единственный источник истины для запланированной работы и её статуса:
 
-On macOS with the Homebrew `openjdk@17` formula:
+1. Начните с [roadmap возрождения Navigation as State](https://github.com/senneco/udf-sandbox/issues/7).
+2. Выберите одну issue с явными acceptance criteria и зависимостями.
+3. Не выходите за scope выбранной issue в pull request.
+4. Если реализация меняет архитектурное решение или инвариант, обновите `docs/PROJECT_CONTEXT.md` в том же pull request.
+
+Не копируйте issue checklists в документацию репозитория. Ссылайтесь на issue, чтобы статус задачи оставался актуальным в одном месте.
+
+## Локальная настройка
+
+Установите Android Studio, нужный Android SDK, эмулятор или устройство и JDK 17. Версия Gradle закреплена wrapper-файлами, а major-версия Java — в `.java-version`.
+
+На macOS с Homebrew `openjdk@17`:
 
 ```bash
 export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
@@ -14,13 +25,23 @@ export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
 ./gradlew testDebugUnitTest lintDebug assembleDebug
 ```
 
-Use a feature branch and open a pull request. Prefer small commits and include tests for changed behavior. UI changes should include a screenshot or short recording.
+## Подход к разработке
 
-## Pull request checklist
+- Перед большим rewrite предпочитайте небольшой behavior-preserving extraction.
+- По возможности оставляйте navigation models, reducers и projection logic чистым Kotlin-кодом.
+- Отделяйте route state от анимации и другого временного presentation state.
+- Добавляйте сфокусированные тесты для изменений push, pop, replace, dismiss, restoration и adaptive projection.
+- Не смешивайте обновление зависимостей или форматирование всего репозитория с изменением поведения.
+- Не включайте credentials, signing material, `local.properties`, персональные данные и generated build output.
 
-Before opening a pull request:
+## Checklist pull request
 
-1. Run `./gradlew testDebugUnitTest lintDebug assembleDebug`.
-2. Check navigation and Android back behavior.
-3. Check state restoration after activity or process recreation where relevant.
-4. Remove secrets and personal data from logs, screenshots, fixtures, and commits.
+Перед открытием pull request:
+
+1. Укажите GitHub issue и объясните, какие acceptance criteria выполнены.
+2. Выполните `./gradlew testDebugUnitTest lintDebug assembleDebug` на JDK 17.
+3. Добавьте или обновите тесты для каждого изменённого state transition или projection rule.
+4. Проверьте Android Back, быстрые повторные события и устаревшие animation callbacks, если это относится к изменению.
+5. Проверьте Activity recreation и process restoration, если это относится к изменению.
+6. Приложите скриншот или короткую запись для видимых UI-изменений и укажите конфигурацию окна.
+7. Явно опишите оставшиеся trade-offs и follow-up work вместо скрытого расширения scope.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,93 @@
 # udf-sandbox
 
-An Android sandbox for experimenting with unidirectional data flow (UDF), Jetpack Compose, navigation, animation, and modal UI state.
+> **Статус:** активный архитектурный эксперимент, который сейчас возрождается. Основная идея выглядит перспективно, но текущая реализация ещё не готова для production.
 
-## Stack
+`udf-sandbox` исследует один вопрос:
 
-- Kotlin and Jetpack Compose
-- A single Android application module
-- Gradle Wrapper with JDK 17
+> Можно ли представить Android-навигацию как обычное состояние приложения и рендерить её с помощью Jetpack Compose, не отдавая владение историей переходов императивному navigation controller?
 
-The project intentionally remains small so state and navigation ideas can be explored in isolation. It is not a production application or a published library.
+Экраны стилизованы под простое банковское приложение, но банковского domain- или data-слоя здесь нет. Они нужны только как понятные fixtures для экспериментов с навигацией, переходами состояния, адаптивным размещением, анимациями и modal UI.
 
-## Run locally
+## Что будет считаться успехом
 
-Open the repository in Android Studio, select JDK 17 for Gradle, install the Android SDK requested by the project, and run the `app` configuration on an emulator or device.
+Navigation as state имеет смысл, только если модель навигации:
 
-Command-line verification:
+- детерминирована: одинаковые state и конфигурация окна дают одинаковое видимое UI-дерево;
+- явна: push, pop, replace, dismiss и restoration являются обычными переходами состояния;
+- тестируется без запуска Compose UI;
+- сериализуется и восстанавливается после process death;
+- описывает fullscreen-, nested- и modal-destinations;
+- не зависит от временного прогресса анимации.
+
+На данном этапе проект не пытается стать универсальной navigation-библиотекой. Это небольшой полигон, на котором свойства подхода можно доказать или опровергнуть.
+
+## Основная идея
+
+Текущий прототип хранит линейный `NavState.backStack`, содержащий и content-, и modal-destinations. `AnimatedNavigation` проецирует эту логическую историю в один или несколько UI-слотов.
+
+Например, один и тот же state рендерится по-разному без изменения navigation history:
+
+| Логическое состояние | Single-pane projection | Multi-pane projection |
+| --- | --- | --- |
+| `Home -> Accounts -> Account(1)` | `Accounts` занимает root, поверх открыт account bottom sheet | `Home` остаётся в root, `Accounts` показан во вложенном слоте, поверх открыт тот же sheet |
+
+Сейчас `HomeScreen.whereToShowChild` приближённо сопоставляет single-pane с portrait, а multi-pane — с landscape. Это demo-упрощение: в целевой архитектуре layout policy станет явным аргументом чистой функции проекции и не будет выводиться только из orientation.
+
+## Целевой UDF-цикл
+
+```mermaid
+flowchart LR
+    UI["Compose UI"] -->|"событие пользователя или системы"| Action["AppAction"]
+    Action --> Reducer["Чистый reducer"]
+    Reducer --> State["AppState + NavState"]
+    State --> Projection["Проекция навигации"]
+    Window["Конфигурация окна"] --> Projection
+    Projection --> UI
+    UI -->|"анимация завершена"| Action
+```
+
+Текущий код уже реализует направление `state -> UI`, но callbacks из UI пока напрямую изменяют глобальный `appState`. Следующий архитектурный шаг — ввести actions, reducer, стабильные back-stack entries и lifecycle-aware store.
+
+## Текущее состояние
+
+Прототип уже демонстрирует:
+
+- back stack, хранящийся в state;
+- push, pop и замену текущей ветки;
+- content и modal destinations в одной логической истории;
+- вложенный рендеринг в landscape;
+- анимированные переходы между content;
+- синхронизацию закрытия bottom sheet обратно в navigation state.
+
+Известные ограничения: распределённые мутации state, незафиксированные инварианты стека, неполная регистрация destinations, хрупкий modal bookkeeping, отсутствие восстановления после process death и поведенческих тестов. Подробный baseline, ограничения и целевая архитектура описаны в [контексте проекта](docs/PROJECT_CONTEXT.md).
+
+## Карта кода
+
+- [`AppState.kt`](app/src/main/java/com/shmakov/udf/AppState.kt) и [`UdfApp.kt`](app/src/main/java/com/shmakov/udf/UdfApp.kt) — текущий глобальный владелец state и начальное demo-состояние.
+- [`navigation/`](app/src/main/java/com/shmakov/udf/navigation) — destinations, navigation state и screen abstractions.
+- [`AnimatedNavigation.kt`](app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt) — проекция стека, вложенный рендеринг, content transitions и modal bookkeeping.
+- [`BottomSheetLayout.kt`](app/src/main/java/com/shmakov/udf/composable/common/BottomSheetLayout.kt) — временное animation state bottom sheet.
+- [`composable/screen/`](app/src/main/java/com/shmakov/udf/composable/screen) — адаптеры экранов и правила размещения дочернего content.
+- [`composable/content/`](app/src/main/java/com/shmakov/udf/composable/content) — минимальный demo UI и текущие navigation triggers.
+
+## Roadmap и задачи
+
+GitHub Issues — единственный источник истины для запланированной работы и её статуса. Начните с [roadmap возрождения Navigation as State](https://github.com/senneco/udf-sandbox/issues/7): в нём задачи расположены по фазам и зависимостям.
+
+Документация объясняет долгоживущие цели и решения, но не дублирует актуальные task checklists.
+
+## Локальный запуск
+
+Требования:
+
+- Android Studio и Android SDK, соответствующий конфигурации проекта;
+- JDK 17;
+- Gradle Wrapper из репозитория.
+
+Запустите конфигурацию `app` в Android Studio или выполните проверку из терминала:
 
 ```bash
 ./gradlew testDebugUnitTest lintDebug assembleDebug
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and pull request expectations.
+Перед началом работы прочитайте [CONTRIBUTING.md](CONTRIBUTING.md). Изменения navigation behavior должны сопровождаться сфокусированными тестами переходов состояния, а видимые UI-изменения — скриншотами или короткой записью.

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -1,0 +1,274 @@
+# Контекст проекта: navigation as state
+
+Этот документ — устойчивый handoff для разработчиков и агентов, которые подключаются к `udf-sandbox` без контекста прошлых обсуждений. Здесь зафиксированы исследовательская цель, baseline, ограничения и направление развития. Актуальный статус работ хранится только в GitHub Issues.
+
+## Цель и критерии успеха
+
+Проект исследует, можно ли представить Android-навигацию как обычное состояние приложения и рендерить её с помощью Jetpack Compose.
+
+Эксперимент считается успешным, если:
+
+1. navigation state является каноническим описанием истории;
+2. события пользователя и системы создают новый state через явные детерминированные переходы;
+3. state вместе с конфигурацией окна однозначно определяет видимое navigation tree;
+4. fullscreen-, nested- и modal-destinations имеют согласованные Back semantics;
+5. state сериализуется и восстанавливается после process death;
+6. transitions и projection тестируются как чистый Kotlin без Compose runtime;
+7. временное animation state не может повредить долгоживущий navigation state.
+
+Ближайшая цель — не публикация navigation framework. Сначала нужно точно сформулировать гипотезу, проверить сложные случаи и понять, какие абстракции действительно полезны.
+
+## Baseline возрождения
+
+- репозиторий: [`senneco/udf-sandbox`](https://github.com/senneco/udf-sandbox);
+- baseline commit: `578c0ca4424b2a2c517771a3c43f90cf7c8ce172`;
+- один Android-модуль `app` на Kotlin и Jetpack Compose;
+- начальная demo-история: `Home -> Accounts -> Account(1)`;
+- unit- и instrumentation-тестов поведения на baseline нет.
+
+Проект остаётся sandbox, а не production-приложением. Текущий код доказывает жизнеспособность идеи, но пока совмещает несколько разных обязанностей внутри Compose.
+
+## Текущая модель
+
+`AppState` содержит `NavState`, а `NavState` содержит:
+
+- `backStack: List<Destination>`;
+- `lastNavActionType: Push | Pop | Replace`.
+
+У `Destination` есть две основные категории:
+
+- `Content` — fullscreen- или nested-экран;
+- `Modal` — сейчас рендерится как bottom sheet.
+
+`AnimatedNavigation(navState, into)` сворачивает back stack и выбирает content для конкретного UI-слота. `Screen.whereToShowChild` может вернуть другой слот, поэтому одна логическая история имеет разные физические layout-проекции.
+
+Для `Home -> Accounts -> Account(1)`:
+
+- в compact/portrait `Accounts` занимает application root, а `Account(1)` показывается как sheet;
+- в expanded/landscape `Home` остаётся в application root, `Accounts` рендерится во вложенном navigator, а над ним показывается тот же sheet.
+
+Таким образом, изменение размера или ориентации окна должно быть изменением рендеринга, а не navigation event. Логическая история остаётся прежней. Это центральная идея, которую важно сохранить.
+
+## Термины
+
+- **Route** — семантическое назначение и его аргументы, например `AccountDetails(accountId = 42)`.
+- **Back-stack entry** — одно конкретное появление route в истории со стабильной идентичностью.
+- **Navigation state** — упорядоченная логическая история entries.
+- **Action** — событие пользователя, системы, lifecycle или завершения presentation-анимации, отправленное владельцу state.
+- **Projection** — детерминированное преобразование navigation state и конфигурации окна в видимое размещение.
+- **Navigation tree** — root content, nested slots и modal layers, которые должен отрисовать Compose.
+
+Route отвечает на вопрос «куда», entry — «какое именно появление». Modal использует presentation UI, но его присутствие в истории остаётся state.
+
+## Эталонные semantics
+
+Эти правила задают общее понимание до начала миграции:
+
+| Событие | State до | State после | Правило |
+| --- | --- | --- | --- |
+| Push | `Home` | `Home -> Accounts` | Новый entry добавляется после текущей верхушки. |
+| Замена ветки | `Home -> Accounts -> Account(1)` | `Home -> Transactions` | Событие исходит от остающегося видимым `Home`: все его потомки удаляются, затем добавляется новый child. Это не простая замена верхнего entry. |
+| Android Back / Pop | `Home -> Accounts -> Account(1)` | `Home -> Accounts` | Удаляется ровно верхний entry. Root не удаляется. |
+| Modal dismiss | `Home -> Accounts -> Account(1)` | `Home -> Accounts` | Reducer удаляет конкретный modal entry по identity; завершение exit-анимации освобождает только presentation state. |
+| Изменение layout | `Home -> Accounts` | `Home -> Accounts` | Меняется только projection, navigation state остаётся прежним. |
+
+Эталонные проекции:
+
+| Navigation state | Single-pane | Multi-pane |
+| --- | --- | --- |
+| `Home` | `Home` | `Home` |
+| `Home -> Accounts` | `Accounts` в root | `Home` в root, `Accounts` во вложенном слоте |
+| `Home -> Accounts -> Account(1)` | `Accounts` и account sheet | `Home`, вложенный `Accounts` и тот же sheet |
+| `Home -> Accounts -> Account(1) -> AccountDetails(1)` | `AccountDetails` в root | `AccountDetails` в root; предыдущая multi-pane projection сохраняется только как outgoing UI до конца exit-анимации |
+
+Последовательный Back из details сначала возвращает projection с account sheet, затем закрывает sheet, затем возвращает `Home`.
+
+## Что уже показал прототип
+
+Можно считать подтверждёнными следующие наблюдения:
+
+- navigation history может храниться в application state;
+- content и modal destinations могут участвовать в единой последовательности Back;
+- responsive placement можно вычислять без переписывания логической истории;
+- branch replacement полезен, когда родитель остаётся видимым и выбирает другого ребёнка;
+- удалённый modal entry иногда нужно временно удерживать в presentation state до завершения exit-анимации.
+
+Пока не доказано, что текущая модель корректна для произвольного валидного state, быстрых событий, lifecycle restoration и сложных анимаций.
+
+## Текущий data flow
+
+Сейчас поток однонаправлен только частично:
+
+```text
+global appState -> Compose rendering
+UI callback     -> direct appState.copy(...)
+```
+
+Typed actions, чистого reducer, effect boundary и lifecycle-aware store пока нет. State transitions распределены между `MainActivity`, demo composables и `AnimatedNavigation`.
+
+## Известные риски и незавершённая работа
+
+### Владение state
+
+- `UdfApp.appState` — глобальный для процесса mutable Compose state.
+- UI и renderer изменяют его напрямую.
+- обычная Activity recreation может случайно сохранить state, но после process death восстанавливается hard-coded начальная история.
+- несколько Activity или task instances разделяли бы один navigation state.
+
+### Модель и идентичность
+
+- `NavState` допускает пустой stack или modal root, хотя renderer ожидает content root.
+- route data и back-stack entry identity смешаны внутри `Destination`.
+- параметризованные destinations используют процессный counter, а singleton destinations не представляют два независимых entry.
+- `lastNavActionType` хранит историческое событие перехода внутри долгоживущего navigation state.
+
+### Проекция и рендеринг
+
+- projection logic находится внутри composable и читает orientation из окружения.
+- registry destinations реализован ручными `when` и завершается небезопасным `!!`.
+- объявленные `Transaction` и `Card` не имеют зарегистрированного content screen.
+- outgoing `AnimatedContent` может получить nested tail, рассчитанный для incoming state, и визуально «прыгнуть» во время exit.
+- screen может запросить nested placement, но забыть отрендерить переданный nested state.
+
+### Modal lifecycle
+
+- предыдущие modal entries хранятся в `AtomicReference`, который изменяется во время composition.
+- modal merge теряет элементы при пакетном добавлении и может упасть при перестановке.
+- отложенный dismiss callback изменяет тот глобальный state, который существует к моменту завершения анимации.
+- завершение bottom sheet определяется точным сравнением `Float` offset с высотой контейнера.
+
+### Back и гонки событий
+
+- Back handler проверяет размер стека во время composition, но callback не проверяет актуальный state перед pop.
+- повторные события до recomposition могут удалить защищённый root.
+- semantics push, pop, replace и dismiss реализованы в разных местах.
+
+### Надёжность и поддержка
+
+- reducer-, projection-, restoration- и UI navigation tests отсутствуют;
+- Android/Compose toolchain отражает исходный прототип и должен обновляться только после появления safety net;
+- demo UI смешивает Material 2 и Material 3.
+
+## Целевая архитектура
+
+Целевой цикл:
+
+```text
+UI/System event
+    -> AppAction
+    -> pure reducer(previous AppState, action)
+    -> new AppState
+    -> project(NavState, WindowConfiguration)
+    -> NavigationTree(root, nested slots, modals)
+    -> Compose rendering
+```
+
+Асинхронная работа и завершение анимаций возвращают явные actions. Они не получают право произвольно изменять любой будущий state.
+
+Предполагаемые границы модели:
+
+```kotlin
+data class BackStackEntry(
+    val id: EntryId,
+    val route: Route,
+)
+
+data class NavState(
+    val entries: NonEmptyList<BackStackEntry>,
+)
+
+fun reduce(state: AppState, action: AppAction): AppState
+
+fun project(
+    navState: NavState,
+    window: WindowConfiguration,
+): NavigationTree
+```
+
+Конкретные типы ещё не являются окончательным решением. Важно отделить стабильную entry identity, сериализуемые route data, чистые transitions, чистую projection и presentation-only animation state.
+
+## Обязательные инварианты
+
+Будущая реализация должна явно обеспечивать и тестировать следующие правила:
+
+1. Пока application task активен, stack не бывает пустым.
+2. Root всегда является renderable content entry.
+3. У каждого entry стабильная identity, не зависящая от route arguments.
+4. `Pop` не удаляет защищённый root.
+5. Завершение dismiss адресует конкретный entry ID и является idempotent.
+6. Каждый route имеет exhaustive renderer или явный unsupported-state result.
+7. Для одинаковых state и window input projection одинакова.
+8. Projection не изменяет application state.
+9. Activity recreation и process restoration воспроизводят ту же логическую историю.
+10. Local UI state сохраняется или осознанно удаляется по entry identity.
+
+## Решения и ограничения
+
+- Сохранять проект небольшим и single-module, пока новая граница не докажет свою пользу.
+- Предпочитать чистый Kotlin для state, reducer и projection.
+- Не смешивать миграцию поведения с массовым обновлением зависимостей или форматированием.
+- Сначала зафиксировать ожидаемое поведение, затем заменять renderer.
+- Передавать в projection явную layout policy; конкретный Android API выбирается отдельно, а orientation остаётся только временным demo-упрощением.
+- Не сохранять animation progress в navigation state.
+- AndroidX Navigation допустим как implementation detail, если application state остаётся каноническим.
+- Каждая behavior-changing issue определяет наблюдаемые acceptance criteria и сфокусированные тесты.
+- GitHub Issues — единственный live task tracker; документация описывает фазы и решения, но не дублирует статус.
+
+## Открытые вопросы дизайна
+
+Это темы для отдельных issues и экспериментов, а не уже принятые решения:
+
+- Должна ли каноническая навигация остаться линейной историей или стать явным деревом?
+- Удаляется ли modal entry в начале dismiss или после завершения exit-анимации?
+- Как представить transition intent, не сохраняя устаревшее событие вроде `lastNavActionType`?
+- Как normalise deep link в валидную navigation history?
+- Как привязать saveable UI state к entry при перемещении projection между слотами?
+- Когда действительно понадобятся multiple back stacks?
+- Как predictive Back интегрируется с reducer-owned navigation state?
+- Может ли Navigation Compose помочь с платформенной интеграцией, не становясь владельцем канонической истории?
+
+## Не-цели фазы возрождения
+
+- реальный data layer для accounts, transactions или cards;
+- выделение reusable library до стабилизации application model;
+- поддержка всех navigation patterns сразу;
+- внедрение большого architecture framework только ради терминологии UDF;
+- обновление всего toolchain в одном изменении с navigation behavior.
+
+## Roadmap
+
+Работа разделена на контракт, deterministic state core, корректный Compose renderer и доказательство lifecycle durability. Обновление toolchain ведётся отдельным maintenance-track. Точный порядок, зависимости и актуальный статус находятся только в [GitHub roadmap](https://github.com/senneco/udf-sandbox/issues/7).
+
+## Как продолжить работу
+
+Новому разработчику или агенту:
+
+1. Прочитать `README.md`, этот документ и `AGENTS.md`.
+2. Выбрать одну GitHub issue и сохранить заявленный scope.
+3. Проверить `git status` перед редактированием и не перезаписывать чужую работу.
+4. Добавить или обновить сфокусированные тесты до изменения state или projection behavior.
+5. Делать commits и pull requests достаточно небольшими, чтобы каждый объяснял один архитектурный шаг.
+6. Сообщать точные результаты проверки и прикладывать UI evidence при изменении рендеринга.
+
+## Важные файлы
+
+- `app/src/main/java/com/shmakov/udf/AppState.kt`
+- `app/src/main/java/com/shmakov/udf/UdfApp.kt`
+- `app/src/main/java/com/shmakov/udf/MainActivity.kt`
+- `app/src/main/java/com/shmakov/udf/navigation/Destination.kt`
+- `app/src/main/java/com/shmakov/udf/navigation/NavState.kt`
+- `app/src/main/java/com/shmakov/udf/navigation/Screen.kt`
+- `app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt`
+- `app/src/main/java/com/shmakov/udf/composable/common/BottomSheetLayout.kt`
+- `app/src/main/java/com/shmakov/udf/composable/content/HomeScreenContent.kt`
+- `app/src/main/java/com/shmakov/udf/composable/content/AccountBottomSheetContent.kt`
+
+## Baseline проверки
+
+Ожидаемая команда проверки репозитория:
+
+```bash
+./gradlew testDebugUnitTest lintDebug assembleDebug
+```
+
+На baseline нет unit- или instrumentation-test sources. До успешного свежего запуска команды на JDK 17 baseline нельзя считать полностью проверенным.


### PR DESCRIPTION
## Зачем

Этот PR фиксирует общий контекст возрождения проекта и формулирует проверяемую гипотезу: может ли навигация быть частью UDF state, а UI — чистой проекцией этого state.

Closes #8

## Что изменилось

- README переписан как входная точка для Android-разработчика без контекста проекта.
- Добавлен `docs/PROJECT_CONTEXT.md` с терминами, reference semantics, инвариантами, текущей и целевой архитектурой, открытыми вопросами и инструкцией продолжения работы.
- `AGENTS.md` и `CONTRIBUTING.md` приведены к принятому стилю разработки и проверки.
- Issue- и PR-шаблоны теперь требуют явно описывать state transitions, projection, инварианты, границы изменения и доказательства поведения.
- Документация связана с roadmap-эпиком #7 и атомарными issues #9–#20.

## Влияние

После merge новый Android-разработчик или агент сможет понять идею проекта, различие route/entry, ожидаемую семантику Back/Pop и multi-pane projection, а также выбрать следующую задачу без восстановления контекста по коду и истории обсуждений.

## Проверка

- `git diff --cached --check`
- разбор всех issue templates как YAML
- проверка существования локальных Markdown-ссылок
- проверка отсутствия trailing whitespace

Gradle-задачи не запускались: изменения затрагивают только Markdown и GitHub YAML-шаблоны, исполняемый код не менялся.