### PR TITLE
Реализовать чистый reducer навигации

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flowchart LR
     UI -->|"анимация завершена"| Action
 ```
 
-Текущий код уже реализует направление `state -> UI`, валидируемую entry model и сохраняемое primitive-представление истории. Callbacks из UI пока напрямую изменяют глобальный `appState`. Следующий архитектурный шаг — ввести typed actions и чистый reducer, а затем lifecycle-aware store и чистую layout projection.
+Navigation core уже содержит валидируемую entry model, сохраняемое primitive-представление истории, typed `NavAction` и чистый `NavReducer`. Reducer возвращает `NavReduction.Changed` с новым state и transient `NavTransitionIntent` либо `NavReduction.Unchanged` с причиной безопасного no-op. Demo UI отправляет actions через одну временную process-global dispatch boundary; lifecycle-aware store и чистая layout projection остаются следующими шагами.
 
 ## Текущее состояние
 
@@ -56,13 +56,15 @@ flowchart LR
 - semantic routes и независимую identity каждого back-stack entry;
 - непустой stack с content-root и уникальными entry IDs;
 - versioned snapshot и расширяемый route codec без Android/Compose dependencies;
-- push, pop и замену текущей ветки;
+- typed push, pop, branch replacement, exact-ID modal dismiss и полную замену history;
+- чистый reducer с явными `Changed`/`Unchanged` outcomes;
+- transient transition intent, который не попадает в `NavState` или snapshot;
 - content и modal destinations в одной логической истории;
 - вложенный рендеринг в landscape;
 - анимированные переходы между content;
 - синхронизацию закрытия bottom sheet обратно в navigation state.
 
-Известные ограничения: распределённые мутации state, неполная регистрация routes, хрупкий modal bookkeeping, отсутствие подключения snapshot к process-death restoration и отсутствие reducer-, projection- и UI-тестов. Подробный baseline, ограничения и целевая архитектура описаны в [контексте проекта](docs/PROJECT_CONTEXT.md).
+Известные ограничения: текущая dispatch boundary всё ещё принадлежит глобальному `Application`, неполная регистрация routes и modal bookkeeping остаются внутри renderer, snapshot не подключён к process-death restoration, а projection-, lifecycle- и UI-тесты ещё отсутствуют. Подробный baseline, ограничения и целевая архитектура описаны в [контексте проекта](docs/PROJECT_CONTEXT.md).
 
 Базовая модель намеренно читается без framework-specific терминов:
 
@@ -78,10 +80,73 @@ val snapshot = state.toSnapshot(DemoRouteCodec)
 
 Обычный код отдаёт генерацию identity фабрикам, а restoration и deep links могут передать заранее известные IDs через `NavState.fromEntries(...)`. Пользовательские routes реализуют ровно один из открытых интерфейсов `ContentRoute` или `ModalRoute` и подключают собственный `RouteCodec`.
 
+## Переходы состояния
+
+Action factories создают identity нового entry до вызова reducer. Поэтому `NavReducer` не генерирует случайные значения, а одинаковые `state + action` всегда дают одинаковый результат.
+
+```kotlin
+object SignedOut : ContentRoute
+
+// Guarded push: stale callback не добавит экран уже в другую ветку.
+val pushed = NavReducer.reduce(
+    state,
+    NavAction.push(state.top.id, AccountDetails(accountId = 42)),
+)
+
+// Android Back удаляет ровно верхний entry и безопасно останавливается на root.
+val back = NavReducer.reduce(pushed.state, NavAction.Pop)
+
+// Если Home не top, NavigateFrom удаляет его descendants и создаёт новую ветку.
+val branch = NavReducer.reduce(
+    state,
+    NavAction.navigateFrom(state.root.id, Transactions),
+)
+
+// Dismiss адресует одно конкретное появление modal route.
+val accountEntry = state.entries.first { it.route is Account }
+val dismissed = NavReducer.reduce(
+    state,
+    NavAction.dismissModal(accountEntry.id),
+)
+
+// Logout и deep link заменяют history атомарно, без серии промежуточных Push.
+val logout = NavReducer.reduce(state, NavAction.resetTo(SignedOut))
+val deepLink = NavReducer.reduce(
+    state,
+    NavAction.replaceHistory(
+        NavState.history(
+            root = Home,
+            Accounts,
+            Account(accountId = 42),
+            AccountDetails(accountId = 42),
+        ),
+    ),
+)
+```
+
+`NavigateFrom` работает как guarded push, когда source уже является top, и как branch replacement, когда после source есть descendants. Отсутствующий или устаревший ID, повторный dismiss и попытка удалить root возвращают тот же `NavState` внутри `NavReduction.Unchanged`; reducer не перенаправляет action на «похожий» route.
+
+`ReplaceHistory` может сохранить старый entry ID только вместе с тем же semantic route. Для новых logout- или deep-link-occurrences используйте свежие IDs; попытка связать прежний ID с другим route возвращает typed `Unchanged`.
+
+`NavTransitionIntent` существует только в `NavReduction.Changed`. Это описание совершившегося перехода для будущего renderer/animation policy, а не часть долгоживущего state:
+
+```kotlin
+when (val reduction = NavReducer.reduce(state, action)) {
+    is NavReduction.Changed -> {
+        reduction.state
+        reduction.transition
+    }
+    is NavReduction.Unchanged -> {
+        reduction.state // тот же instance
+        reduction.reason
+    }
+}
+```
+
 ## Карта кода
 
 - [`AppState.kt`](app/src/main/java/com/shmakov/udf/AppState.kt) и [`UdfApp.kt`](app/src/main/java/com/shmakov/udf/UdfApp.kt) — текущий глобальный владелец state и начальное demo-состояние.
-- [`navigation/`](app/src/main/java/com/shmakov/udf/navigation) — routes, back-stack entries, валидируемый navigation state, snapshot/codec и screen abstractions.
+- [`navigation/`](app/src/main/java/com/shmakov/udf/navigation) — routes, back-stack entries, валидируемый navigation state, actions/reducer, snapshot/codec и screen abstractions.
 - [`AnimatedNavigation.kt`](app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt) — проекция стека, вложенный рендеринг, content transitions и modal bookkeeping.
 - [`BottomSheetLayout.kt`](app/src/main/java/com/shmakov/udf/composable/common/BottomSheetLayout.kt) — временное animation state bottom sheet.
 - [`composable/screen/`](app/src/main/java/com/shmakov/udf/composable/screen) — адаптеры экранов и правила размещения дочернего content.

--- a/app/src/main/java/com/shmakov/udf/AppState.kt
+++ b/app/src/main/java/com/shmakov/udf/AppState.kt
@@ -1,10 +1,8 @@
 package com.shmakov.udf
 
-import com.shmakov.udf.navigation.NavActionType
 import com.shmakov.udf.navigation.NavState
 
 data class AppState(
     val navState: NavState,
-    val lastNavActionType: NavActionType,
     val showInPlace: Boolean,
 )

--- a/app/src/main/java/com/shmakov/udf/MainActivity.kt
+++ b/app/src/main/java/com/shmakov/udf/MainActivity.kt
@@ -11,9 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.shmakov.udf.UdfApp.Companion.appState
 import com.shmakov.udf.composable.common.AnimatedNavigation
-import com.shmakov.udf.navigation.NavActionType
-import com.shmakov.udf.navigation.NavState
-import com.shmakov.udf.navigation.requireValid
+import com.shmakov.udf.navigation.NavAction
+import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.ui.theme.UDFTheme
 
 class MainActivity : ComponentActivity() {
@@ -22,19 +21,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
+            val currentAppState = appState
+            val currentNavTransition = UdfApp.navTransition
 
-            BackHandler(enabled = appState.navState.entries.size > 1) {
-                val currentState = appState
-                val currentEntries = currentState.navState.entries
-
-                if (currentEntries.size > 1) {
-                    appState = currentState.copy(
-                        navState = NavState.fromEntries(
-                            currentEntries.dropLast(1),
-                        ).requireValid(),
-                        lastNavActionType = NavActionType.Pop,
-                    )
-                }
+            BackHandler(enabled = currentAppState.navState.entries.size > 1) {
+                UdfApp.dispatchNavigation(NavAction.Pop)
             }
 
 
@@ -44,17 +35,23 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    AppContent(appState)
+                    AppContent(
+                        appState = currentAppState,
+                        navTransition = currentNavTransition,
+                    )
                 }
             }
         }
     }
 
     @Composable
-    private fun AppContent(appState: AppState) {
+    private fun AppContent(
+        appState: AppState,
+        navTransition: NavTransitionIntent?,
+    ) {
         AnimatedNavigation(
             navState = appState.navState,
-            lastNavActionType = appState.lastNavActionType,
+            navTransition = navTransition,
         )
     }
 }

--- a/app/src/main/java/com/shmakov/udf/UdfApp.kt
+++ b/app/src/main/java/com/shmakov/udf/UdfApp.kt
@@ -8,6 +8,11 @@ import com.shmakov.udf.navigation.*
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
+private data class AppFrame(
+    val state: AppState,
+    val navTransition: NavTransitionIntent?,
+)
+
 class UdfApp : Application() {
 
     override fun onCreate() {
@@ -22,16 +27,39 @@ class UdfApp : Application() {
     }
 
     companion object {
-        var appState by mutableStateOf(
-            AppState(
-                navState = NavState.history(
-                    root = Home,
-                    Accounts,
-                    Account(accountId = 1),
-                ),
-                lastNavActionType = NavActionType.Replace,
-                showInPlace = false,
-            )
+        private var frame by mutableStateOf(
+            NavState.history(
+                root = Home,
+                Accounts,
+                Account(accountId = 1),
+            ).let { initialNavState ->
+                AppFrame(
+                    state = AppState(
+                        navState = initialNavState,
+                        showInPlace = false,
+                    ),
+                    navTransition = null,
+                )
+            },
         )
+
+        val appState: AppState
+            get() = frame.state
+
+        val navTransition: NavTransitionIntent?
+            get() = frame.navTransition
+
+        @JvmStatic
+        fun dispatchNavigation(action: NavAction): NavReduction {
+            val reduction = NavReducer.reduce(frame.state.navState, action)
+            if (reduction is NavReduction.Changed) {
+                frame = AppFrame(
+                    state = frame.state.copy(navState = reduction.state),
+                    navTransition = reduction.transition,
+                )
+            }
+
+            return reduction
+        }
     }
 }

--- a/app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import com.shmakov.udf.UdfApp.Companion.appState
+import com.shmakov.udf.UdfApp
 import com.shmakov.udf.composable.screen.AccountBottomSheet
 import com.shmakov.udf.composable.screen.AccountDetailsScreen
 import com.shmakov.udf.composable.screen.AccountsScreen
@@ -32,23 +32,23 @@ import com.shmakov.udf.navigation.Home
 import com.shmakov.udf.navigation.ModalRoute
 import com.shmakov.udf.navigation.ModalScreen
 import com.shmakov.udf.navigation.ModalScreenState
-import com.shmakov.udf.navigation.NavActionType
+import com.shmakov.udf.navigation.NavAction
 import com.shmakov.udf.navigation.NavState
+import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.RenderSlot
 import com.shmakov.udf.navigation.Screen
 import com.shmakov.udf.navigation.Transactions
-import com.shmakov.udf.navigation.requireValid
 import java.util.concurrent.atomic.AtomicReference
 
 @Composable
 fun AnimatedNavigation(
     navState: NavState,
-    lastNavActionType: NavActionType,
+    navTransition: NavTransitionIntent?,
 ) {
     AnimatedNavigation(
         entries = navState.entries,
         into = RenderSlot.Root,
-        lastNavActionType = lastNavActionType,
+        navTransition = navTransition,
     )
 }
 
@@ -56,7 +56,7 @@ fun AnimatedNavigation(
 internal fun AnimatedNavigation(
     entries: List<BackStackEntry>,
     into: RenderSlot,
-    lastNavActionType: NavActionType,
+    navTransition: NavTransitionIntent?,
 ) {
     val rootEntry = entries.firstOrNull() ?: return
 
@@ -95,18 +95,24 @@ internal fun AnimatedNavigation(
         } ?: rootEntry
 
     val finalEnter: AnimatedContentScope<BackStackEntry>.() -> EnterTransition = {
-        when (lastNavActionType) {
-            NavActionType.Push -> appPushEnterTransition
-            NavActionType.Pop -> appPopEnterTransition
-            NavActionType.Replace -> appReplaceEnterTransition
+        when (navTransition) {
+            is NavTransitionIntent.Pushed -> appPushEnterTransition
+            is NavTransitionIntent.Popped,
+            is NavTransitionIntent.ModalDismissed -> appPopEnterTransition
+            is NavTransitionIntent.BranchReplaced,
+            is NavTransitionIntent.HistoryReplaced,
+            null -> appReplaceEnterTransition
         }
     }
 
     val finalExit: AnimatedContentScope<BackStackEntry>.() -> ExitTransition = {
-        when (lastNavActionType) {
-            NavActionType.Push -> appPushExitTransition
-            NavActionType.Pop -> appPopExitTransition
-            NavActionType.Replace -> appReplaceExitTransition
+        when (navTransition) {
+            is NavTransitionIntent.Pushed -> appPushExitTransition
+            is NavTransitionIntent.Popped,
+            is NavTransitionIntent.ModalDismissed -> appPopExitTransition
+            is NavTransitionIntent.BranchReplaced,
+            is NavTransitionIntent.HistoryReplaced,
+            null -> appReplaceExitTransition
         }
     }
 
@@ -126,7 +132,7 @@ internal fun AnimatedNavigation(
 
         getContentScreen(entry).Content(
             nestedEntries = nestedEntries,
-            lastNavActionType = lastNavActionType,
+            navTransition = navTransition,
         )
 
         val modalEntries = entries
@@ -176,14 +182,7 @@ internal fun AnimatedNavigation(
                             items.filterNot { it.id == item.id }
                         }
 
-                        val currentState = appState
-                        appState = currentState.copy(
-                            navState = NavState.fromEntries(
-                                currentState.navState.entries.filterNot {
-                                    it.id == item.id
-                                },
-                            ).requireValid(),
-                        )
+                        UdfApp.dispatchNavigation(NavAction.DismissModal(item.id))
                     },
                 )
             }

--- a/app/src/main/java/com/shmakov/udf/composable/content/AccountBottomSheetContent.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/content/AccountBottomSheetContent.kt
@@ -10,24 +10,21 @@ import com.shmakov.udf.UdfApp
 import com.shmakov.udf.navigation.Account
 import com.shmakov.udf.navigation.AccountDetails
 import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavActionType
-import com.shmakov.udf.navigation.NavState
-import com.shmakov.udf.navigation.requireValid
+import com.shmakov.udf.navigation.NavAction
 
 @Composable
 fun ColumnScope.AccountBottomSheetContent(
+    currentEntry: BackStackEntry,
     accountId: Int,
 ) {
     if (accountId < 9) {
         Button(
             onClick = {
-                UdfApp.appState = UdfApp.appState.copy(
-                    navState = NavState.fromEntries(
-                        UdfApp.appState.navState.entries + BackStackEntry.create(
-                            Account(accountId = accountId + 1),
-                        ),
-                    ).requireValid(),
-                    lastNavActionType = NavActionType.Push,
+                UdfApp.dispatchNavigation(
+                    NavAction.push(
+                        expectedTopId = currentEntry.id,
+                        route = Account(accountId = accountId + 1),
+                    ),
                 )
             },
         ) {
@@ -37,15 +34,11 @@ fun ColumnScope.AccountBottomSheetContent(
 
     Button(
         onClick = {
-            UdfApp.appState = UdfApp.appState.copy(
-                navState = NavState.fromEntries(
-                    UdfApp.appState.navState.entries + BackStackEntry.create(
-                        AccountDetails(
-                            accountId = accountId,
-                        ),
-                    ),
-                ).requireValid(),
-                lastNavActionType = NavActionType.Push,
+            UdfApp.dispatchNavigation(
+                NavAction.push(
+                    expectedTopId = currentEntry.id,
+                    route = AccountDetails(accountId = accountId),
+                ),
             )
         },
         modifier = Modifier

--- a/app/src/main/java/com/shmakov/udf/composable/content/AccountsScreenContent.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/content/AccountsScreenContent.kt
@@ -8,15 +8,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.shmakov.udf.UdfApp.Companion.appState
+import com.shmakov.udf.UdfApp
 import com.shmakov.udf.navigation.Account
 import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavActionType
-import com.shmakov.udf.navigation.NavState
-import com.shmakov.udf.navigation.requireValid
+import com.shmakov.udf.navigation.NavAction
 
 @Composable
-fun AccountsScreenContent() {
+fun AccountsScreenContent(currentEntry: BackStackEntry) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -27,18 +25,18 @@ fun AccountsScreenContent() {
         )
 
         for (i in 1..10) {
-            Button(onClick = { navigateTo(i) }) {
+            Button(onClick = { navigateTo(currentEntry, i) }) {
                 Text(text = "Go to Account $i")
             }
         }
     }
 }
 
-private fun navigateTo(id: Int) {
-    appState = appState.copy(
-        navState = NavState.fromEntries(
-            appState.navState.entries + BackStackEntry.create(Account(accountId = id)),
-        ).requireValid(),
-        lastNavActionType = NavActionType.Push,
+private fun navigateTo(currentEntry: BackStackEntry, id: Int) {
+    UdfApp.dispatchNavigation(
+        NavAction.push(
+            expectedTopId = currentEntry.id,
+            route = Account(accountId = id),
+        ),
     )
 }

--- a/app/src/main/java/com/shmakov/udf/composable/content/HomeScreenContent.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/content/HomeScreenContent.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
-import com.shmakov.udf.UdfApp.Companion.appState
+import com.shmakov.udf.UdfApp
 import com.shmakov.udf.composable.common.AnimatedNavigation
 import com.shmakov.udf.navigation.*
 
@@ -19,7 +19,7 @@ import com.shmakov.udf.navigation.*
 fun HomeScreenContent(
     currentEntry: BackStackEntry,
     nestedEntries: List<BackStackEntry>,
-    lastNavActionType: NavActionType,
+    navTransition: NavTransitionIntent?,
 ) {
     Column(
         modifier = Modifier
@@ -46,7 +46,7 @@ fun HomeScreenContent(
             AnimatedNavigation(
                 entries = nestedEntries,
                 into = RenderSlot.Nested(currentEntry.id),
-                lastNavActionType = lastNavActionType,
+                navTransition = navTransition,
             )
         }
     }
@@ -71,28 +71,14 @@ fun Buttons(
     }
 }
 
-// TODO: move to reducer
 private fun navigateTo(
     currentEntry: BackStackEntry,
     targetRoute: ContentRoute,
 ) {
-    val currentEntryIndex = appState.navState.entries.indexOfFirst {
-        it.id == currentEntry.id
-    }
-
-    if (currentEntryIndex == -1) return
-
-    val navActionType = if (currentEntryIndex == appState.navState.entries.lastIndex) {
-        NavActionType.Push
-    } else {
-        NavActionType.Replace
-    }
-
-    appState = appState.copy(
-        navState = NavState.fromEntries(
-            appState.navState.entries.take(currentEntryIndex + 1) +
-                BackStackEntry.create(targetRoute),
-        ).requireValid(),
-        lastNavActionType = navActionType,
+    UdfApp.dispatchNavigation(
+        NavAction.navigateFrom(
+            sourceId = currentEntry.id,
+            route = targetRoute,
+        ),
     )
 }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/AccountBottomSheet.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/AccountBottomSheet.kt
@@ -16,6 +16,7 @@ class AccountBottomSheet(
         val route = entry.route as Account
 
         AccountBottomSheetContent(
+            currentEntry = entry,
             accountId = route.accountId,
         )
     }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/AccountDetailsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/AccountDetailsScreen.kt
@@ -11,7 +11,7 @@ class AccountDetailsScreen(
     @Composable
     override fun Content(
         nestedEntries: List<BackStackEntry>,
-        lastNavActionType: NavActionType,
+        navTransition: NavTransitionIntent?,
     ) {
         val route = entry.route as AccountDetails
 

--- a/app/src/main/java/com/shmakov/udf/composable/screen/AccountsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/AccountsScreen.kt
@@ -3,7 +3,7 @@ package com.shmakov.udf.composable.screen
 import androidx.compose.runtime.Composable
 import com.shmakov.udf.composable.content.AccountsScreenContent
 import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavActionType
+import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.Screen
 
 class AccountsScreen(
@@ -13,8 +13,8 @@ class AccountsScreen(
     @Composable
     override fun Content(
         nestedEntries: List<BackStackEntry>,
-        lastNavActionType: NavActionType,
+        navTransition: NavTransitionIntent?,
     ) {
-        AccountsScreenContent()
+        AccountsScreenContent(currentEntry = entry)
     }
 }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/CardsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/CardsScreen.kt
@@ -3,7 +3,7 @@ package com.shmakov.udf.composable.screen
 import androidx.compose.runtime.Composable
 import com.shmakov.udf.composable.content.CardsScreenContent
 import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavActionType
+import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.Screen
 
 class CardsScreen(
@@ -13,7 +13,7 @@ class CardsScreen(
     @Composable
     override fun Content(
         nestedEntries: List<BackStackEntry>,
-        lastNavActionType: NavActionType,
+        navTransition: NavTransitionIntent?,
     ) {
         CardsScreenContent()
     }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/HomeScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/HomeScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalConfiguration
 import com.shmakov.udf.composable.content.HomeScreenContent
 import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavActionType
+import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.RenderSlot
 import com.shmakov.udf.navigation.Screen
 
@@ -32,12 +32,12 @@ class HomeScreen(
     @Composable
     override fun Content(
         nestedEntries: List<BackStackEntry>,
-        lastNavActionType: NavActionType,
+        navTransition: NavTransitionIntent?,
     ) {
         HomeScreenContent(
             currentEntry = entry,
             nestedEntries = nestedEntries,
-            lastNavActionType = lastNavActionType,
+            navTransition = navTransition,
         )
     }
 }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/TransactionsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/TransactionsScreen.kt
@@ -3,7 +3,7 @@ package com.shmakov.udf.composable.screen
 import androidx.compose.runtime.Composable
 import com.shmakov.udf.composable.content.TransactionsScreenContent
 import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavActionType
+import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.Screen
 
 class TransactionsScreen(
@@ -13,7 +13,7 @@ class TransactionsScreen(
     @Composable
     override fun Content(
         nestedEntries: List<BackStackEntry>,
-        lastNavActionType: NavActionType,
+        navTransition: NavTransitionIntent?,
     ) {
         TransactionsScreenContent()
     }

--- a/app/src/main/java/com/shmakov/udf/navigation/NavActionType.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/NavActionType.kt
@@ -1,7 +1,0 @@
-package com.shmakov.udf.navigation
-
-enum class NavActionType {
-    Push,
-    Pop,
-    Replace,
-}

--- a/app/src/main/java/com/shmakov/udf/navigation/NavigationReducer.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/NavigationReducer.kt
@@ -1,0 +1,334 @@
+package com.shmakov.udf.navigation
+
+import java.util.Collections
+
+/** A fully materialized navigation operation consumed by [NavReducer]. */
+sealed class NavAction {
+
+    data class Push(
+        val expectedTopId: EntryId,
+        val entry: BackStackEntry,
+    ) : NavAction()
+
+    object Pop : NavAction()
+
+    data class NavigateFrom(
+        val sourceId: EntryId,
+        val entry: BackStackEntry,
+    ) : NavAction()
+
+    data class DismissModal(
+        val entryId: EntryId,
+    ) : NavAction()
+
+    data class ReplaceHistory(
+        val target: NavState,
+    ) : NavAction()
+
+    companion object {
+        /** Materializes a new entry before reduction. */
+        @JvmStatic
+        fun push(expectedTopId: EntryId, route: Route): Push =
+            Push(expectedTopId, BackStackEntry.create(route))
+
+        /** Uses a caller-supplied identity, which is useful for replay and tests. */
+        @JvmStatic
+        fun push(expectedTopId: EntryId, entry: BackStackEntry): Push =
+            Push(expectedTopId, entry)
+
+        /** Materializes a new entry before reduction. */
+        @JvmStatic
+        fun navigateFrom(sourceId: EntryId, route: Route): NavigateFrom =
+            NavigateFrom(sourceId, BackStackEntry.create(route))
+
+        /** Uses a caller-supplied identity, which is useful for replay and tests. */
+        @JvmStatic
+        fun navigateFrom(sourceId: EntryId, entry: BackStackEntry): NavigateFrom =
+            NavigateFrom(sourceId, entry)
+
+        @JvmStatic
+        fun pop(): Pop = Pop
+
+        @JvmStatic
+        fun dismissModal(entryId: EntryId): DismissModal = DismissModal(entryId)
+
+        @JvmStatic
+        fun replaceHistory(target: NavState): ReplaceHistory = ReplaceHistory(target)
+
+        /** Creates a fresh root entry before reduction and replaces the complete history. */
+        @JvmStatic
+        fun resetTo(rootRoute: ContentRoute): ReplaceHistory =
+            ReplaceHistory(NavState.startAt(rootRoute))
+    }
+}
+
+/** Semantic description of one applied navigation change. It is not durable state. */
+sealed class NavTransitionIntent {
+
+    data class Pushed(
+        val fromEntryId: EntryId,
+        val addedEntryId: EntryId,
+    ) : NavTransitionIntent()
+
+    data class Popped(
+        val removedEntryId: EntryId,
+        val revealedEntryId: EntryId,
+    ) : NavTransitionIntent()
+
+    class BranchReplaced(
+        val sourceEntryId: EntryId,
+        removedEntryIds: List<EntryId>,
+        val addedEntryId: EntryId,
+    ) : NavTransitionIntent() {
+        val removedEntryIds: List<EntryId> = immutableListCopy(removedEntryIds)
+
+        override fun equals(other: Any?): Boolean =
+            this === other ||
+                other is BranchReplaced &&
+                sourceEntryId == other.sourceEntryId &&
+                removedEntryIds == other.removedEntryIds &&
+                addedEntryId == other.addedEntryId
+
+        override fun hashCode(): Int {
+            var result = sourceEntryId.hashCode()
+            result = 31 * result + removedEntryIds.hashCode()
+            result = 31 * result + addedEntryId.hashCode()
+            return result
+        }
+
+        override fun toString(): String =
+            "BranchReplaced(sourceEntryId=$sourceEntryId, " +
+                "removedEntryIds=$removedEntryIds, addedEntryId=$addedEntryId)"
+    }
+
+    data class ModalDismissed(
+        val entryId: EntryId,
+    ) : NavTransitionIntent()
+
+    data class HistoryReplaced(
+        val previousTopEntryId: EntryId,
+        val targetTopEntryId: EntryId,
+    ) : NavTransitionIntent()
+}
+
+/** The deterministic reason why a valid action left navigation state unchanged. */
+sealed class NavUnchangedReason {
+
+    data class EntryNotFound(
+        val entryId: EntryId,
+    ) : NavUnchangedReason()
+
+    data class SourceIsNotTop(
+        val expectedTopId: EntryId,
+        val actualTopId: EntryId,
+    ) : NavUnchangedReason()
+
+    data class EntryIdAlreadyExists(
+        val entryId: EntryId,
+    ) : NavUnchangedReason()
+
+    class InvalidResultingState(
+        problems: List<NavStateProblem>,
+    ) : NavUnchangedReason() {
+        val problems: List<NavStateProblem> = immutableListCopy(problems)
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is InvalidResultingState && problems == other.problems
+
+        override fun hashCode(): Int = problems.hashCode()
+
+        override fun toString(): String = "InvalidResultingState(problems=$problems)"
+    }
+
+    object RootProtected : NavUnchangedReason()
+
+    data class EntryIsNotModal(
+        val entryId: EntryId,
+    ) : NavUnchangedReason()
+
+    object AlreadyAtTarget : NavUnchangedReason()
+
+    data class EntryIdentityRebound(
+        val entryId: EntryId,
+        val previousRoute: Route,
+        val targetRoute: Route,
+    ) : NavUnchangedReason()
+}
+
+/** Result of reducing one [NavAction]. */
+sealed class NavReduction {
+    abstract val state: NavState
+
+    data class Changed(
+        override val state: NavState,
+        val transition: NavTransitionIntent,
+    ) : NavReduction()
+
+    data class Unchanged(
+        override val state: NavState,
+        val reason: NavUnchangedReason,
+    ) : NavReduction()
+}
+
+/** Pure, deterministic navigation-state reducer. */
+object NavReducer {
+
+    @JvmStatic
+    fun reduce(state: NavState, action: NavAction): NavReduction = when (action) {
+        is NavAction.Push -> push(state, action)
+        NavAction.Pop -> pop(state)
+        is NavAction.NavigateFrom -> navigateFrom(state, action)
+        is NavAction.DismissModal -> dismissModal(state, action)
+        is NavAction.ReplaceHistory -> replaceHistory(state, action)
+    }
+
+    private fun push(state: NavState, action: NavAction.Push): NavReduction {
+        val expectedTopIndex = state.entries.indexOfFirst { it.id == action.expectedTopId }
+        if (expectedTopIndex == -1) {
+            return state.unchanged(NavUnchangedReason.EntryNotFound(action.expectedTopId))
+        }
+        if (expectedTopIndex != state.entries.lastIndex) {
+            return state.unchanged(
+                NavUnchangedReason.SourceIsNotTop(
+                    expectedTopId = action.expectedTopId,
+                    actualTopId = state.top.id,
+                ),
+            )
+        }
+        if (state.contains(action.entry.id)) {
+            return state.unchanged(NavUnchangedReason.EntryIdAlreadyExists(action.entry.id))
+        }
+
+        return reduceEntries(
+            previousState = state,
+            entries = state.entries + action.entry,
+            transition = NavTransitionIntent.Pushed(
+                fromEntryId = action.expectedTopId,
+                addedEntryId = action.entry.id,
+            ),
+        )
+    }
+
+    private fun pop(state: NavState): NavReduction {
+        if (state.entries.size == 1) {
+            return state.unchanged(NavUnchangedReason.RootProtected)
+        }
+
+        val removedEntry = state.top
+        val remainingEntries = state.entries.dropLast(1)
+        return reduceEntries(
+            previousState = state,
+            entries = remainingEntries,
+            transition = NavTransitionIntent.Popped(
+                removedEntryId = removedEntry.id,
+                revealedEntryId = remainingEntries.last().id,
+            ),
+        )
+    }
+
+    private fun navigateFrom(
+        state: NavState,
+        action: NavAction.NavigateFrom,
+    ): NavReduction {
+        val sourceIndex = state.entries.indexOfFirst { it.id == action.sourceId }
+        if (sourceIndex == -1) {
+            return state.unchanged(NavUnchangedReason.EntryNotFound(action.sourceId))
+        }
+        if (state.contains(action.entry.id)) {
+            return state.unchanged(NavUnchangedReason.EntryIdAlreadyExists(action.entry.id))
+        }
+
+        val removedEntries = state.entries.drop(sourceIndex + 1)
+        val transition = if (removedEntries.isEmpty()) {
+            NavTransitionIntent.Pushed(
+                fromEntryId = action.sourceId,
+                addedEntryId = action.entry.id,
+            )
+        } else {
+            NavTransitionIntent.BranchReplaced(
+                sourceEntryId = action.sourceId,
+                removedEntryIds = removedEntries.map { it.id },
+                addedEntryId = action.entry.id,
+            )
+        }
+
+        return reduceEntries(
+            previousState = state,
+            entries = state.entries.take(sourceIndex + 1) + action.entry,
+            transition = transition,
+        )
+    }
+
+    private fun dismissModal(
+        state: NavState,
+        action: NavAction.DismissModal,
+    ): NavReduction {
+        val modalIndex = state.entries.indexOfFirst { it.id == action.entryId }
+        if (modalIndex == -1) {
+            return state.unchanged(NavUnchangedReason.EntryNotFound(action.entryId))
+        }
+        if (state.entries[modalIndex].route !is ModalRoute) {
+            return state.unchanged(NavUnchangedReason.EntryIsNotModal(action.entryId))
+        }
+
+        return reduceEntries(
+            previousState = state,
+            entries = state.entries.filterIndexed { index, _ -> index != modalIndex },
+            transition = NavTransitionIntent.ModalDismissed(action.entryId),
+        )
+    }
+
+    private fun replaceHistory(
+        state: NavState,
+        action: NavAction.ReplaceHistory,
+    ): NavReduction {
+        if (state == action.target) {
+            return state.unchanged(NavUnchangedReason.AlreadyAtTarget)
+        }
+
+        val previousEntriesById = state.entries.associateBy { it.id }
+        action.target.entries.forEach { targetEntry ->
+            val previousEntry = previousEntriesById[targetEntry.id] ?: return@forEach
+            if (previousEntry.route != targetEntry.route) {
+                return state.unchanged(
+                    NavUnchangedReason.EntryIdentityRebound(
+                        entryId = targetEntry.id,
+                        previousRoute = previousEntry.route,
+                        targetRoute = targetEntry.route,
+                    ),
+                )
+            }
+        }
+
+        return NavReduction.Changed(
+            state = action.target,
+            transition = NavTransitionIntent.HistoryReplaced(
+                previousTopEntryId = state.top.id,
+                targetTopEntryId = action.target.top.id,
+            ),
+        )
+    }
+
+    private fun reduceEntries(
+        previousState: NavState,
+        entries: List<BackStackEntry>,
+        transition: NavTransitionIntent,
+    ): NavReduction = when (val result = NavState.fromEntries(entries)) {
+        is NavStateCreationResult.Valid -> NavReduction.Changed(
+            state = result.state,
+            transition = transition,
+        )
+        is NavStateCreationResult.Invalid -> previousState.unchanged(
+            NavUnchangedReason.InvalidResultingState(result.problems),
+        )
+    }
+
+    private fun NavState.contains(entryId: EntryId): Boolean =
+        entries.any { it.id == entryId }
+
+    private fun NavState.unchanged(reason: NavUnchangedReason): NavReduction.Unchanged =
+        NavReduction.Unchanged(state = this, reason = reason)
+}
+
+private fun <T> immutableListCopy(source: Collection<T>): List<T> =
+    Collections.unmodifiableList(ArrayList(source))

--- a/app/src/main/java/com/shmakov/udf/navigation/Screen.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/Screen.kt
@@ -17,7 +17,7 @@ abstract class Screen(
     @Composable
     abstract fun Content(
         nestedEntries: List<BackStackEntry>,
-        lastNavActionType: NavActionType,
+        navTransition: NavTransitionIntent?,
     )
 }
 

--- a/app/src/test/java/com/shmakov/udf/navigation/NavigationJavaApiTest.java
+++ b/app/src/test/java/com/shmakov/udf/navigation/NavigationJavaApiTest.java
@@ -1,0 +1,38 @@
+package com.shmakov.udf.navigation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import org.junit.Test;
+
+public final class NavigationJavaApiTest {
+
+    @Test
+    public void staticFactoriesAndReducerAreUsableWithoutKotlinCompanionSyntax() {
+        BackStackEntry root = new BackStackEntry(new EntryId("home"), Home.INSTANCE);
+        NavStateCreationResult created = NavState.fromEntries(Collections.singletonList(root));
+        assertTrue(created instanceof NavStateCreationResult.Valid);
+        NavState state = ((NavStateCreationResult.Valid) created).getState();
+
+        NavAction.Push push = NavAction.push(state.getTop().getId(), Accounts.INSTANCE);
+        NavAction.NavigateFrom navigate = NavAction.navigateFrom(
+                state.getRoot().getId(),
+                Transactions.INSTANCE
+        );
+        NavAction.DismissModal dismiss = NavAction.dismissModal(new EntryId("modal"));
+        NavAction.ReplaceHistory replace = NavAction.replaceHistory(state);
+        NavAction.ReplaceHistory reset = NavAction.resetTo(Home.INSTANCE);
+
+        NavReduction reduction = NavReducer.reduce(state, push);
+
+        assertTrue(reduction instanceof NavReduction.Changed);
+        assertEquals(Accounts.INSTANCE, reduction.getState().getTop().getRoute());
+        assertSame(NavAction.Pop.INSTANCE, NavAction.pop());
+        assertEquals(state.getRoot().getId(), navigate.getSourceId());
+        assertEquals(new EntryId("modal"), dismiss.getEntryId());
+        assertSame(state, replace.getTarget());
+        assertEquals(Home.INSTANCE, reset.getTarget().getRoot().getRoute());
+    }
+}

--- a/app/src/test/java/com/shmakov/udf/navigation/NavigationReducerContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/navigation/NavigationReducerContractTest.kt
@@ -1,0 +1,626 @@
+package com.shmakov.udf.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavigationReducerContractTest {
+
+    @Test
+    fun `action factories materialize identity before reduction`() {
+        val push = NavAction.push(EntryId("home"), Accounts)
+        val anotherPush = NavAction.push(EntryId("home"), Accounts)
+        val navigate = NavAction.navigateFrom(EntryId("home"), Transactions)
+        val target = state(entry("signed-out", SignedOut))
+
+        assertEquals(EntryId("home"), push.expectedTopId)
+        assertEquals(Accounts, push.entry.route)
+        assertTrue(push.entry.id.value.isNotBlank())
+        assertNotEquals(push.entry.id, anotherPush.entry.id)
+        assertEquals(EntryId("home"), navigate.sourceId)
+        assertEquals(Transactions, navigate.entry.route)
+        assertEquals(NavAction.Pop, NavAction.pop())
+        assertEquals(
+            NavAction.DismissModal(EntryId("modal")),
+            NavAction.dismissModal(EntryId("modal")),
+        )
+        assertEquals(NavAction.ReplaceHistory(target), NavAction.replaceHistory(target))
+        assertEquals(SignedOut, NavAction.resetTo(SignedOut).target.root.route)
+    }
+
+    @Test
+    fun `push appends supplied content entry and reports exact intent`() {
+        val initial = state(entry("home", Home))
+        val accounts = entry("accounts", Accounts)
+
+        val result = changed(
+            NavReducer.reduce(
+                initial,
+                NavAction.Push(expectedTopId = initial.top.id, entry = accounts),
+            ),
+        )
+
+        assertEquals(listOf(initial.root, accounts), result.state.entries)
+        assertEquals(
+            NavTransitionIntent.Pushed(
+                fromEntryId = initial.root.id,
+                addedEntryId = accounts.id,
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `push accepts modal content after modal and repeated routes with distinct IDs`() {
+        val first = entry("account-1", Account(42))
+        val initial = state(entry("home", Home), first)
+        val second = entry("account-2", Account(42))
+        val details = entry("details", AccountDetails(42))
+
+        val withSecond = changed(
+            NavReducer.reduce(
+                initial,
+                NavAction.Push(expectedTopId = first.id, entry = second),
+            ),
+        ).state
+        val withDetails = changed(
+            NavReducer.reduce(
+                withSecond,
+                NavAction.Push(expectedTopId = second.id, entry = details),
+            ),
+        ).state
+
+        assertEquals(
+            listOf(Home, Account(42), Account(42), AccountDetails(42)),
+            withDetails.entries.map(BackStackEntry::route),
+        )
+        assertNotEquals(first.id, second.id)
+    }
+
+    @Test
+    fun `push with missing or non-top source is a typed no-op`() {
+        val initial = state(entry("home", Home), entry("accounts", Accounts))
+
+        val missing = unchanged(
+            NavReducer.reduce(
+                initial,
+                NavAction.Push(EntryId("stale"), entry("details", AccountDetails(1))),
+            ),
+        )
+        val nonTop = unchanged(
+            NavReducer.reduce(
+                initial,
+                NavAction.Push(initial.root.id, entry("details-2", AccountDetails(2))),
+            ),
+        )
+
+        assertSame(initial, missing.state)
+        assertEquals(
+            NavUnchangedReason.EntryNotFound(EntryId("stale")),
+            missing.reason,
+        )
+        assertSame(initial, nonTop.state)
+        assertEquals(
+            NavUnchangedReason.SourceIsNotTop(
+                expectedTopId = initial.root.id,
+                actualTopId = initial.top.id,
+            ),
+            nonTop.reason,
+        )
+    }
+
+    @Test
+    fun `push rejects an ID already present in history`() {
+        val initial = state(entry("home", Home), entry("accounts", Accounts))
+
+        val result = unchanged(
+            NavReducer.reduce(
+                initial,
+                NavAction.Push(
+                    expectedTopId = initial.top.id,
+                    entry = entry("home", AccountDetails(1)),
+                ),
+            ),
+        )
+
+        assertSame(initial, result.state)
+        assertEquals(
+            NavUnchangedReason.EntryIdAlreadyExists(EntryId("home")),
+            result.reason,
+        )
+    }
+
+    @Test
+    fun `push returns every invalid resulting-state problem without throwing`() {
+        val initial = state(entry("home", Home))
+        val invalidEntries = listOf(
+            entry("  ", Accounts) to listOf(NavStateProblem.BlankEntryId(index = 1)),
+            entry("missing-kind", MissingKindRoute) to listOf(
+                NavStateProblem.MissingRouteKind(EntryId("missing-kind")),
+            ),
+            entry("ambiguous-kind", AmbiguousKindRoute) to listOf(
+                NavStateProblem.AmbiguousRouteKind(EntryId("ambiguous-kind")),
+            ),
+        )
+
+        invalidEntries.forEach { (invalidEntry, expectedProblems) ->
+            val result = unchanged(
+                NavReducer.reduce(
+                    initial,
+                    NavAction.Push(initial.top.id, invalidEntry),
+                ),
+            )
+
+            assertSame(initial, result.state)
+            assertEquals(
+                NavUnchangedReason.InvalidResultingState(expectedProblems),
+                result.reason,
+            )
+        }
+    }
+
+    @Test
+    fun `pop removes exactly one content or modal top`() {
+        val histories = listOf(
+            state(entry("home", Home), entry("accounts", Accounts)),
+            state(entry("home", Home), entry("account", Account(1))),
+        )
+
+        histories.forEach { initial ->
+            val removed = initial.top
+            val result = changed(NavReducer.reduce(initial, NavAction.Pop))
+
+            assertEquals(listOf(initial.root), result.state.entries)
+            assertEquals(
+                NavTransitionIntent.Popped(
+                    removedEntryId = removed.id,
+                    revealedEntryId = initial.root.id,
+                ),
+                result.transition,
+            )
+        }
+    }
+
+    @Test
+    fun `pop protects root and returns the same state instance`() {
+        val initial = state(entry("home", Home))
+
+        val result = unchanged(NavReducer.reduce(initial, NavAction.Pop))
+
+        assertSame(initial, result.state)
+        assertEquals(NavUnchangedReason.RootProtected, result.reason)
+    }
+
+    @Test
+    fun `rapid pops deterministically stop at root`() {
+        val initial = state(
+            entry("home", Home),
+            entry("accounts", Accounts),
+            entry("account", Account(1)),
+        )
+
+        val reductions = generateSequence<NavReduction>(
+            NavReducer.reduce(initial, NavAction.Pop),
+        ) { previous -> NavReducer.reduce(previous.state, NavAction.Pop) }
+            .take(5)
+            .toList()
+
+        assertEquals(listOf(Home), reductions.last().state.entries.map(BackStackEntry::route))
+        assertTrue(reductions.take(2).all { it is NavReduction.Changed })
+        assertTrue(reductions.drop(2).all { it is NavReduction.Unchanged })
+        assertSame(reductions[1].state, reductions.last().state)
+    }
+
+    @Test
+    fun `navigateFrom removes every descendant and reports their IDs in order`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(1))
+        val initial = state(home, accounts, account)
+        val transactions = entry("transactions", Transactions)
+
+        val result = changed(
+            NavReducer.reduce(
+                initial,
+                NavAction.NavigateFrom(home.id, transactions),
+            ),
+        )
+
+        assertEquals(listOf(home, transactions), result.state.entries)
+        assertEquals(
+            NavTransitionIntent.BranchReplaced(
+                sourceEntryId = home.id,
+                removedEntryIds = listOf(accounts.id, account.id),
+                addedEntryId = transactions.id,
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `navigateFrom top is a guarded push`() {
+        val initial = state(entry("home", Home), entry("accounts", Accounts))
+        val account = entry("account", Account(1))
+
+        val result = changed(
+            NavReducer.reduce(
+                initial,
+                NavAction.NavigateFrom(initial.top.id, account),
+            ),
+        )
+
+        assertEquals(initial.entries + account, result.state.entries)
+        assertEquals(
+            NavTransitionIntent.Pushed(initial.top.id, account.id),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `navigateFrom selects a duplicate route occurrence by ID`() {
+        val firstAccounts = entry("accounts-1", Accounts)
+        val secondAccounts = entry("accounts-2", Accounts)
+        val initial = state(
+            entry("home", Home),
+            firstAccounts,
+            entry("account", Account(1)),
+            secondAccounts,
+            entry("details", AccountDetails(1)),
+        )
+        val cards = entry("cards", Cards)
+
+        val result = changed(
+            NavReducer.reduce(
+                initial,
+                NavAction.NavigateFrom(secondAccounts.id, cards),
+            ),
+        )
+
+        assertEquals(
+            listOf(Home, Accounts, Account(1), Accounts, Cards),
+            result.state.entries.map(BackStackEntry::route),
+        )
+        assertEquals(firstAccounts.id, result.state.entries[1].id)
+        assertEquals(secondAccounts.id, result.state.entries[3].id)
+    }
+
+    @Test
+    fun `navigateFrom permits a modal anchor`() {
+        val modal = entry("account", Account(1))
+        val initial = state(entry("home", Home), modal, entry("old-details", AccountDetails(1)))
+        val newDetails = entry("new-details", AccountDetails(2))
+
+        val result = changed(
+            NavReducer.reduce(initial, NavAction.NavigateFrom(modal.id, newDetails)),
+        )
+
+        assertEquals(listOf(initial.root, modal, newDetails), result.state.entries)
+    }
+
+    @Test
+    fun `navigateFrom missing source is a typed no-op`() {
+        val initial = state(entry("home", Home), entry("accounts", Accounts))
+        val staleId = EntryId("stale")
+
+        val result = unchanged(
+            NavReducer.reduce(
+                initial,
+                NavAction.NavigateFrom(staleId, entry("cards", Cards)),
+            ),
+        )
+
+        assertSame(initial, result.state)
+        assertEquals(NavUnchangedReason.EntryNotFound(staleId), result.reason)
+    }
+
+    @Test
+    fun `navigateFrom rejects an ID present even in the removed suffix`() {
+        val home = entry("home", Home)
+        val suffixId = EntryId("accounts")
+        val initial = state(home, BackStackEntry(suffixId, Accounts))
+
+        val result = unchanged(
+            NavReducer.reduce(
+                initial,
+                NavAction.NavigateFrom(
+                    sourceId = home.id,
+                    entry = BackStackEntry(suffixId, Transactions),
+                ),
+            ),
+        )
+
+        assertSame(initial, result.state)
+        assertEquals(NavUnchangedReason.EntryIdAlreadyExists(suffixId), result.reason)
+    }
+
+    @Test
+    fun `navigateFrom validates every replacement entry without throwing`() {
+        val home = entry("home", Home)
+        val initial = state(home, entry("accounts", Accounts))
+        val invalidEntries = listOf(
+            entry(" ", Transactions) to listOf(NavStateProblem.BlankEntryId(index = 1)),
+            entry("missing-kind", MissingKindRoute) to listOf(
+                NavStateProblem.MissingRouteKind(EntryId("missing-kind")),
+            ),
+            entry("ambiguous-kind", AmbiguousKindRoute) to listOf(
+                NavStateProblem.AmbiguousRouteKind(EntryId("ambiguous-kind")),
+            ),
+        )
+
+        invalidEntries.forEach { (invalidEntry, expectedProblems) ->
+            val result = unchanged(
+                NavReducer.reduce(
+                    initial,
+                    NavAction.NavigateFrom(home.id, invalidEntry),
+                ),
+            )
+
+            assertSame(initial, result.state)
+            assertEquals(
+                NavUnchangedReason.InvalidResultingState(expectedProblems),
+                result.reason,
+            )
+        }
+    }
+
+    @Test
+    fun `dismissModal removes exactly a top modal by identity`() {
+        val modal = entry("account", Account(1))
+        val initial = state(entry("home", Home), entry("accounts", Accounts), modal)
+
+        val result = changed(
+            NavReducer.reduce(initial, NavAction.DismissModal(modal.id)),
+        )
+
+        assertEquals(initial.entries.dropLast(1), result.state.entries)
+        assertEquals(NavTransitionIntent.ModalDismissed(modal.id), result.transition)
+    }
+
+    @Test
+    fun `dismissModal removes only the addressed middle modal`() {
+        val first = entry("account-1", Account(1))
+        val second = entry("account-2", Account(2))
+        val details = entry("details", AccountDetails(2))
+        val initial = state(entry("home", Home), first, second, details)
+
+        val result = changed(
+            NavReducer.reduce(initial, NavAction.DismissModal(first.id)),
+        )
+
+        assertEquals(listOf(initial.root, second, details), result.state.entries)
+        assertEquals(NavTransitionIntent.ModalDismissed(first.id), result.transition)
+    }
+
+    @Test
+    fun `dismissModal distinguishes duplicate routes by entry ID`() {
+        val first = entry("account-1", Account(42))
+        val second = entry("account-2", Account(42))
+        val initial = state(entry("home", Home), first, second)
+
+        val result = changed(
+            NavReducer.reduce(initial, NavAction.DismissModal(first.id)),
+        )
+
+        assertEquals(listOf(initial.root, second), result.state.entries)
+    }
+
+    @Test
+    fun `dismissModal missing or content entry is a typed no-op`() {
+        val initial = state(entry("home", Home), entry("accounts", Accounts))
+        val stale = EntryId("stale")
+
+        val missing = unchanged(
+            NavReducer.reduce(initial, NavAction.DismissModal(stale)),
+        )
+        val content = unchanged(
+            NavReducer.reduce(initial, NavAction.DismissModal(initial.top.id)),
+        )
+
+        assertSame(initial, missing.state)
+        assertEquals(NavUnchangedReason.EntryNotFound(stale), missing.reason)
+        assertSame(initial, content.state)
+        assertEquals(
+            NavUnchangedReason.EntryIsNotModal(initial.top.id),
+            content.reason,
+        )
+    }
+
+    @Test
+    fun `repeated modal dismiss is idempotent`() {
+        val modal = entry("account", Account(1))
+        val initial = state(entry("home", Home), modal)
+        val first = changed(
+            NavReducer.reduce(initial, NavAction.DismissModal(modal.id)),
+        )
+        val second = unchanged(
+            NavReducer.reduce(first.state, NavAction.DismissModal(modal.id)),
+        )
+
+        assertEquals(listOf(Home), first.state.entries.map(BackStackEntry::route))
+        assertSame(first.state, second.state)
+        assertEquals(NavUnchangedReason.EntryNotFound(modal.id), second.reason)
+    }
+
+    @Test
+    fun `replaceHistory atomically swaps logout and deep-link histories`() {
+        val initial = state(
+            entry("home", Home),
+            entry("accounts", Accounts),
+            entry("account", Account(1)),
+        )
+        val logout = state(entry("signed-out", SignedOut))
+        val deepLink = state(
+            entry("deep-home", Home),
+            entry("deep-accounts", Accounts),
+            entry("deep-account", Account(42)),
+            entry("deep-details", AccountDetails(42)),
+        )
+
+        listOf(logout, deepLink).forEach { target ->
+            val result = changed(
+                NavReducer.reduce(initial, NavAction.ReplaceHistory(target)),
+            )
+
+            assertSame(target, result.state)
+            assertEquals(
+                NavTransitionIntent.HistoryReplaced(
+                    previousTopEntryId = initial.top.id,
+                    targetTopEntryId = target.top.id,
+                ),
+                result.transition,
+            )
+        }
+    }
+
+    @Test
+    fun `replaceHistory equal target is a typed no-op`() {
+        val initial = state(entry("home", Home), entry("accounts", Accounts))
+        val equalTarget = state(*initial.entries.toTypedArray())
+
+        val result = unchanged(
+            NavReducer.reduce(initial, NavAction.ReplaceHistory(equalTarget)),
+        )
+
+        assertSame(initial, result.state)
+        assertEquals(NavUnchangedReason.AlreadyAtTarget, result.reason)
+    }
+
+    @Test
+    fun `replaceHistory may preserve identity for the same semantic route`() {
+        val sharedRoot = entry("shared-home", Home)
+        val initial = state(sharedRoot, entry("old-accounts", Accounts))
+        val target = state(sharedRoot, entry("new-transactions", Transactions))
+
+        val result = changed(
+            NavReducer.reduce(initial, NavAction.ReplaceHistory(target)),
+        )
+
+        assertSame(target, result.state)
+        assertEquals(sharedRoot, result.state.root)
+        assertEquals(
+            NavTransitionIntent.HistoryReplaced(
+                previousTopEntryId = initial.top.id,
+                targetTopEntryId = target.top.id,
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `replaceHistory rejects rebinding a stable ID to another route`() {
+        val sharedId = EntryId("shared")
+        val initial = state(BackStackEntry(sharedId, Home))
+        val target = state(BackStackEntry(sharedId, SignedOut))
+
+        val result = unchanged(
+            NavReducer.reduce(initial, NavAction.ReplaceHistory(target)),
+        )
+
+        assertSame(initial, result.state)
+        assertEquals(
+            NavUnchangedReason.EntryIdentityRebound(
+                entryId = sharedId,
+                previousRoute = Home,
+                targetRoute = SignedOut,
+            ),
+            result.reason,
+        )
+    }
+
+    @Test
+    fun `the same materialized action sequence produces the same reductions`() {
+        val initial = state(entry("home", Home))
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(1))
+        val actions = listOf(
+            NavAction.Push(initial.top.id, accounts),
+            NavAction.NavigateFrom(accounts.id, account),
+            NavAction.DismissModal(account.id),
+            NavAction.Pop,
+            NavAction.Pop,
+        )
+
+        val first = reduceAll(initial, actions)
+        val second = reduceAll(initial, actions)
+
+        assertEquals(first, second)
+        assertEquals(listOf(Home), first.last().state.entries.map(BackStackEntry::route))
+        assertTrue(first.last() is NavReduction.Unchanged)
+    }
+
+    @Test
+    fun `replaying the same push action cannot duplicate its entry ID`() {
+        val initial = state(entry("home", Home))
+        val action = NavAction.Push(initial.top.id, entry("accounts", Accounts))
+        val first = changed(NavReducer.reduce(initial, action))
+
+        val replay = unchanged(
+            NavReducer.reduce(
+                first.state,
+                action.copy(expectedTopId = first.state.top.id),
+            ),
+        )
+
+        assertSame(first.state, replay.state)
+        assertEquals(
+            NavUnchangedReason.EntryIdAlreadyExists(action.entry.id),
+            replay.reason,
+        )
+    }
+
+    @Test
+    fun `snapshot of reduced state contains no transition intent`() {
+        val initial = state(entry("home", Home))
+        val action = NavAction.Push(initial.top.id, entry("accounts", Accounts))
+        val result = changed(NavReducer.reduce(initial, action))
+
+        assertEquals(
+            result.state.toSnapshot(DemoRouteCodec),
+            state(entry("home", Home), entry("accounts", Accounts))
+                .toSnapshot(DemoRouteCodec),
+        )
+    }
+
+    private fun reduceAll(
+        initial: NavState,
+        actions: List<NavAction>,
+    ): List<NavReduction> {
+        var current = initial
+        return actions.map { action ->
+            NavReducer.reduce(current, action).also { current = it.state }
+        }
+    }
+
+    private fun changed(result: NavReduction): NavReduction.Changed = when (result) {
+        is NavReduction.Changed -> result
+        is NavReduction.Unchanged -> throw AssertionError(
+            "Expected state change, got ${result.reason}",
+        )
+    }
+
+    private fun unchanged(result: NavReduction): NavReduction.Unchanged = when (result) {
+        is NavReduction.Changed -> throw AssertionError(
+            "Expected no-op, got ${result.transition}",
+        )
+        is NavReduction.Unchanged -> result
+    }
+
+    private fun state(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> throw AssertionError(
+                "Invalid test fixture: ${result.problems}",
+            )
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        BackStackEntry(EntryId(id), route)
+
+    private object SignedOut : ContentRoute
+
+    private object MissingKindRoute : Route
+
+    private object AmbiguousKindRoute : ContentRoute, ModalRoute
+}

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -34,9 +34,11 @@
 
 Открытые `ContentRoute` и `ModalRoute` позволяют приложению объявлять собственные routes. Versioned primitive snapshot отделён от route objects; приложение подключает их через `RouteCodec`, а восстановление всегда повторно использует validation `NavState`.
 
-Временный `lastNavActionType: Push | Pop | Replace` больше не является частью сериализуемого `NavState`, но до появления reducer всё ещё хранится в demo `AppState`.
+Navigation input представлен закрытым набором typed `NavAction`, а `NavReducer.reduce(state, action)` является чистой Kotlin-функцией. Результат — `NavReduction.Changed(state, transition)` либо `NavReduction.Unchanged(state, reason)`. Action factories материализуют identity новых entries до reduction, поэтому reducer не генерирует случайные значения.
 
-`AnimatedNavigation(navState, lastNavActionType)` сворачивает entries и выбирает content для конкретного внутреннего render slot. `Screen.whereToShowChild` может вернуть другой слот, поэтому одна логическая история имеет разные физические layout-проекции.
+`NavTransitionIntent` описывает только что совершившийся Push, Pop, branch replacement, modal dismiss или full-history replacement. Он возвращается отдельно от durable `NavState` и не попадает в snapshot. Временный `UdfApp` удерживает последний intent рядом с `AppState` в process-local render envelope до следующего `Changed`, а renderer использует его для выбора legacy motion. Одноразовое consumption, lifecycle-aware store и настраиваемая animation policy появятся отдельными инкрементами.
+
+`AnimatedNavigation(navState, navTransition)` сворачивает entries и выбирает content для конкретного внутреннего render slot. `Screen.whereToShowChild` может вернуть другой слот, поэтому одна логическая история имеет разные физические layout-проекции.
 
 Для `Home -> Accounts -> Account(1)`:
 
@@ -51,6 +53,8 @@
 - **Back-stack entry** — одно конкретное появление route в истории со стабильной идентичностью.
 - **Navigation state** — упорядоченная логическая история entries.
 - **Action** — событие пользователя, системы, lifecycle или завершения presentation-анимации, отправленное владельцу state.
+- **Reduction** — результат чистого применения `NavAction`: изменённый state с transient transition intent либо тот же state с typed причиной no-op.
+- **Transition intent** — эфемерное описание совершившегося navigation transition; оно не является частью `NavState` и не восстанавливается из snapshot.
 - **Projection** — детерминированное преобразование navigation state и конфигурации окна в видимое размещение.
 - **Navigation tree** — root content, nested slots и modal layers, которые должен отрисовать Compose.
 
@@ -62,10 +66,11 @@ Route отвечает на вопрос «куда», entry — «какое и
 
 | Событие | State до | State после | Правило |
 | --- | --- | --- | --- |
-| Push | `Home` | `Home -> Accounts` | Новый entry добавляется после текущей верхушки. |
-| Замена ветки | `Home -> Accounts -> Account(1)` | `Home -> Transactions` | Событие исходит от остающегося видимым `Home`: все его потомки удаляются, затем добавляется новый child. Это не простая замена верхнего entry. |
+| Guarded Push | `Home` | `Home -> Accounts` | Новый entry добавляется, только если указанный `expectedTopId` всё ещё является top. |
+| `NavigateFrom` / замена ветки | `Home -> Accounts -> Account(1)` | `Home -> Transactions` | Для остающегося `Home` все descendants удаляются, затем добавляется новый child. Если source уже top, это guarded push. |
 | Android Back / Pop | `Home -> Accounts -> Account(1)` | `Home -> Accounts` | Удаляется ровно верхний entry. Root не удаляется. |
-| Modal dismiss | `Home -> Accounts -> Account(1)` | `Home -> Accounts` | Reducer удаляет конкретный modal entry по identity; завершение exit-анимации освобождает только presentation state. |
+| Exact modal dismiss | `Home -> Accounts -> Account(1)` | `Home -> Accounts` | Reducer удаляет только указанный modal entry по identity; повторный или stale dismiss является no-op. |
+| `ReplaceHistory` | любая history | валидная target history | Logout и deep link заменяют state одной атомарной action, без наблюдаемых промежуточных Push. Сохранённый ID обязан по-прежнему обозначать тот же semantic route. |
 | Изменение layout | `Home -> Accounts` | `Home -> Accounts` | Меняется только projection, navigation state остаётся прежним. |
 
 Эталонные проекции:
@@ -86,39 +91,53 @@ Route отвечает на вопрос «куда», entry — «какое и
 - navigation history может храниться в application state;
 - route equality можно отделить от стабильной identity каждого появления route;
 - структурные инварианты и snapshot round trip можно тестировать как чистый Kotlin;
+- typed navigation actions и reducer transitions можно тестировать без Android и Compose;
+- stale actions и защищённый root дают явный `Unchanged`, не исключение и не скрытый переход;
 - content и modal destinations могут участвовать в единой последовательности Back;
 - responsive placement можно вычислять без переписывания логической истории;
 - branch replacement полезен, когда родитель остаётся видимым и выбирает другого ребёнка;
 - удалённый modal entry иногда нужно временно удерживать в presentation state до завершения exit-анимации.
 
-Пока не доказана корректность reducer/projection/renderer для произвольного валидного state, быстрых событий, lifecycle restoration и сложных анимаций.
+Reducer contract покрывает эталонные state transitions и подключён к одной временной runtime boundary, но lifecycle-aware store, чистая projection, renderer races, lifecycle restoration и сложные анимации ещё не доказаны end-to-end.
 
 ## Текущий data flow
 
-Сейчас поток однонаправлен только частично:
+Чистое navigation core уже имеет однонаправленную границу:
 
 ```text
-global appState -> Compose rendering
-UI callback     -> direct appState.copy(...)
+NavState + NavAction
+    -> NavReducer
+    -> NavReduction.Changed(newState, NavTransitionIntent)
+     | NavReduction.Unchanged(sameState, reason)
 ```
 
-Typed actions, чистого reducer, effect boundary и lifecycle-aware store пока нет. State transitions распределены между `MainActivity`, demo composables и `AnimatedNavigation`.
+В demo runtime все navigation mutations уже проходят через одну boundary:
+
+```text
+UI callback -> UdfApp.dispatchNavigation(NavAction)
+            -> NavReducer
+            -> AppState + transient NavTransitionIntent
+            -> Compose rendering
+```
+
+`appState` доступен UI только для чтения; `MainActivity`, demo composables и modal callback больше не собирают history вручную. Эта boundary всё ещё process-global и не lifecycle-aware; effect boundary, чистая projection и настраиваемая reducer-to-renderer animation policy пока отсутствуют.
 
 ## Известные риски и незавершённая работа
 
 ### Владение state
 
-- `UdfApp.appState` — глобальный для процесса mutable Compose state.
-- UI и renderer изменяют его напрямую.
+- `UdfApp` всё ещё владеет глобальным для процесса Compose frame, хотя `appState` снаружи доступен только для чтения.
+- UI и renderer отправляют typed actions в `dispatchNavigation`, но эта временная boundary не привязана к lifecycle конкретной Activity.
 - обычная Activity recreation может случайно сохранить state, но после process death восстанавливается hard-coded начальная история.
 - несколько Activity или task instances разделяли бы один navigation state.
 
 ### Модель и идентичность
 
 - `NavState` уже отделяет semantic route от entry identity и отклоняет empty stack, non-content root, неоднозначный route kind, blank или duplicate IDs.
-- ID создаётся на application boundary и сохраняется как строка; будущий pure reducer не должен генерировать случайность внутри reduction.
+- ID создаётся action factory на application boundary и сохраняется как строка; `NavReducer` не генерирует случайность внутри reduction.
 - primitive snapshot и codec существуют, но ещё не подключены к `SavedStateHandle` и process-death lifecycle.
-- `lastNavActionType` вынесен из сериализуемого `NavState`, но его окончательный transient-контракт должен определить reducer.
+- `NavTransitionIntent` вынесен из durable state и snapshot; renderer пока сводит его к жёстко заданным legacy motions без отдельной policy.
+- `ReplaceHistory` разрешает пересечение old/target IDs только для тех же routes; для новых deeplink- и logout-occurrences следует создавать свежие IDs.
 
 ### Проекция и рендеринг
 
@@ -132,18 +151,18 @@ Typed actions, чистого reducer, effect boundary и lifecycle-aware store 
 
 - предыдущие modal entries хранятся в `AtomicReference`, который изменяется во время composition.
 - modal merge теряет элементы при пакетном добавлении и может упасть при перестановке.
-- отложенный dismiss callback изменяет тот глобальный state, который существует к моменту завершения анимации.
+- отложенный dismiss callback dispatch-ит durable action только после завершения анимации; request и completion пока не разделены.
 - завершение bottom sheet определяется точным сравнением `Float` offset с высотой контейнера.
 
 ### Back и гонки событий
 
-- `NavState` и повторная проверка в Back callback защищают root от удаления.
-- остальные быстрые события всё ещё выполняют распределённые read-modify-write и будут сериализованы только единым store.
-- semantics push, pop, replace и dismiss реализованы в разных местах.
+- `NavState` и `NavReducer` защищают root независимо от устаревшего состояния UI callback.
+- pure reducer детерминированно останавливает быстрые Pop на root и возвращает typed no-op для stale IDs.
+- demo callbacks dispatch-ят actions через одну process-global boundary; lifecycle и конкурентное владение будут формализованы единым store.
 
 ### Надёжность и поддержка
 
-- model/identity/snapshot покрыты pure Kotlin contract tests, но reducer-, projection-, lifecycle- и UI navigation tests ещё отсутствуют;
+- model, identity, snapshot и reducer покрыты pure Kotlin contract tests, но projection-, lifecycle- и UI navigation tests ещё отсутствуют;
 - Android/Compose toolchain отражает исходный прототип и должен обновляться только после появления safety net;
 - demo UI смешивает Material 2 и Material 3.
 
@@ -154,8 +173,10 @@ Typed actions, чистого reducer, effect boundary и lifecycle-aware store 
 ```text
 UI/System event
     -> AppAction
-    -> pure reducer(previous AppState, action)
-    -> new AppState
+    -> state owner
+    -> NavReducer.reduce(previous NavState, NavAction)
+    -> NavReduction
+    -> new AppState + transient NavTransitionIntent
     -> project(NavState, WindowConfiguration)
     -> NavigationTree(root, nested slots, modals)
     -> Compose rendering
@@ -175,7 +196,12 @@ data class NavState(
     val entries: NonEmptyList<BackStackEntry>,
 )
 
-fun reduce(state: AppState, action: AppAction): AppState
+object NavReducer {
+    fun reduce(
+        state: NavState,
+        action: NavAction,
+    ): NavReduction
+}
 
 fun project(
     navState: NavState,
@@ -183,7 +209,7 @@ fun project(
 ): NavigationTree
 ```
 
-Route, entry identity, validated `NavState` и primitive snapshot уже реализуют первую границу этой схемы. Конкретные reducer-, projection- и animation-типы ещё не являются окончательным решением.
+Route, entry identity, validated `NavState`, primitive snapshot и pure navigation reducer уже реализуют deterministic core этой схемы. Временная runtime boundary передаёт transition intent renderer-у; lifecycle-aware state owner, чистая projection и настраиваемая animation policy ещё не реализованы.
 
 ## Обязательные инварианты
 
@@ -193,7 +219,7 @@ Route, entry identity, validated `NavState` и primitive snapshot уже реа�
 2. Root всегда является renderable content entry.
 3. У каждого entry стабильная identity, не зависящая от route arguments.
 4. `Pop` не удаляет защищённый root.
-5. Завершение dismiss адресует конкретный entry ID и является idempotent.
+5. Durable modal dismiss адресует конкретный entry ID и является idempotent; animation completion меняет только presentation state.
 6. Каждый route имеет exhaustive renderer или явный unsupported-state result.
 7. Для одинаковых state и window input projection одинакова.
 8. Projection не изменяет application state.
@@ -208,6 +234,8 @@ Route, entry identity, validated `NavState` и primitive snapshot уже реа�
 - Сначала зафиксировать ожидаемое поведение, затем заменять renderer.
 - Передавать в projection явную layout policy; конкретный Android API выбирается отдельно, а orientation остаётся только временным demo-упрощением.
 - Не сохранять animation progress в navigation state.
+- Не сохранять `NavTransitionIntent` в navigation state или snapshot; `Unchanged` не создаёт transition.
+- Logout и deep link заменяют полную валидную history атомарным `ReplaceHistory`.
 - AndroidX Navigation допустим как implementation detail, если application state остаётся каноническим.
 - Каждая behavior-changing issue определяет наблюдаемые acceptance criteria и сфокусированные тесты.
 - GitHub Issues — единственный live task tracker; документация описывает фазы и решения, но не дублирует статус.
@@ -218,7 +246,7 @@ Route, entry identity, validated `NavState` и primitive snapshot уже реа�
 
 - Должна ли каноническая навигация остаться линейной историей или стать явным деревом?
 - Удаляется ли modal entry в начале dismiss или после завершения exit-анимации?
-- Как представить transition intent, не сохраняя устаревшее событие вроде `lastNavActionType`?
+- Как Compose renderer будет сопоставлять transient `NavTransitionIntent` с настраиваемой animation policy?
 - Как normalise deep link в валидную navigation history?
 - Как привязать saveable UI state к entry при перемещении projection между слотами?
 - Когда действительно понадобятся multiple back stacks?
@@ -256,6 +284,7 @@ Route, entry identity, validated `NavState` и primitive snapshot уже реа�
 - `app/src/main/java/com/shmakov/udf/navigation/Route.kt`
 - `app/src/main/java/com/shmakov/udf/navigation/NavState.kt`
 - `app/src/main/java/com/shmakov/udf/navigation/NavStateSnapshot.kt`
+- `app/src/main/java/com/shmakov/udf/navigation/NavigationReducer.kt`
 - `app/src/main/java/com/shmakov/udf/navigation/Screen.kt`
 - `app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt`
 - `app/src/main/java/com/shmakov/udf/composable/common/BottomSheetLayout.kt`


### PR DESCRIPTION
Closes #10

## Что изменено

- Добавлен pure Kotlin `NavReducer` и закрытый набор typed actions: guarded `Push`, `Pop`, `NavigateFrom`, exact-ID `DismissModal`, атомарный `ReplaceHistory`.
- Результат явно разделён на `NavReduction.Changed(state, transition)` и `Unchanged(sameState, reason)`; transient `NavTransitionIntent` не входит в `NavState` или snapshot.
- Новые entry IDs материализуются до reduction; stale IDs, root protection, duplicate IDs, invalid routes и identity rebound дают детерминированные typed no-op.
- Demo runtime переведён на одну `UdfApp.dispatchNavigation` boundary. `appState` доступен UI только для чтения, `NavActionType` удалён, ручная сборка histories из composables исчезла.
- README и architectural context содержат Kotlin-примеры push/back/branch/dismiss/logout/deep link и честно фиксируют оставшиеся lifecycle/projection/animation ограничения.

## Проверки

- TDD: исходный focused suite падал на отсутствующем reducer API; после реализации GREEN.
- `JAVA_HOME=...17 ./gradlew testDebugUnitTest lintDebug assembleDebug` — PASS.
- 62 unit tests: 28 reducer, 1 Java consumer ABI, 16 model, 17 snapshot; 0 failures/errors/skipped.
- `git diff --check` — PASS.
- GitHub Actions: Android CI и CodeQL — PASS.
- Независимые architecture, external API и test reviews: P0–P2 закрыты.
- Изолированный Pixel_4 (`emulator-5556`, отдельный от занятого `5554`): cold launch → Account modal → details → Back восстанавливает modal → Back удаляет modal → Back возвращает Home. На каждом шаге проверена Compose hierarchy; процесс приложения жив, `AndroidRuntime` crash-log пуст. Локальные снимки сохранены как `/private/tmp/udf-issue-10-details-5556.png` и `/private/tmp/udf-issue-10-back-5556.png`.

## Вне scope

Lifecycle-aware store, pure layout projection, retained-modal model, bottom-sheet handshake и configurable animation policy остаются в следующих roadmap issues.