### PR TITLE
Сделать ViewModel/store владельцем AppState

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flowchart LR
     UI -->|"анимация завершена"| Action
 ```
 
-Navigation core уже содержит валидируемую entry model, сохраняемое primitive-представление истории, typed `NavAction` и чистый `NavReducer`. Reducer возвращает `NavReduction.Changed` с новым state и transient `NavTransitionIntent` либо `NavReduction.Unchanged` с причиной безопасного no-op. Demo UI отправляет actions через одну временную process-global dispatch boundary; lifecycle-aware store и чистая layout projection остаются следующими шагами.
+Navigation core уже содержит валидируемую entry model, сохраняемое primitive-представление истории, typed `NavAction` и чистый `NavReducer`. Activity-scoped `AppViewModel` владеет demo-specific `AppStore`, публикует immutable frames через read-only `StateFlow` и сериализует actions перед reducer. Compose наблюдает flow с учётом lifecycle и передаёт события наверх через явные callbacks. Следующий архитектурный шаг — чистая layout projection.
 
 ## Текущее состояние
 
@@ -59,12 +59,14 @@ Navigation core уже содержит валидируемую entry model, с
 - typed push, pop, branch replacement, exact-ID modal dismiss и полную замену history;
 - чистый reducer с явными `Changed`/`Unchanged` outcomes;
 - transient transition intent, который не попадает в `NavState` или snapshot;
+- lifecycle-aware ViewModel и linearizable store как единственную demo-boundary для durable state;
+- lifecycle-aware Compose collection и явные callbacks без глобальных state imports в UI;
 - content и modal destinations в одной логической истории;
 - вложенный рендеринг в landscape;
 - анимированные переходы между content;
 - синхронизацию закрытия bottom sheet обратно в navigation state.
 
-Известные ограничения: текущая dispatch boundary всё ещё принадлежит глобальному `Application`, неполная регистрация routes и modal bookkeeping остаются внутри renderer, snapshot не подключён к process-death restoration, а projection-, lifecycle- и UI-тесты ещё отсутствуют. Подробный baseline, ограничения и целевая архитектура описаны в [контексте проекта](docs/PROJECT_CONTEXT.md).
+Известные ограничения: store пока является внутренней demo-интеграцией, snapshot не подключён к process-death restoration, а неполная регистрация routes, layout projection и modal bookkeeping остаются внутри renderer. Projection- и lifecycle-restoration tests ещё отсутствуют. Подробный baseline, ограничения и целевая архитектура описаны в [контексте проекта](docs/PROJECT_CONTEXT.md).
 
 Базовая модель намеренно читается без framework-specific терминов:
 
@@ -143,9 +145,30 @@ when (val reduction = NavReducer.reduce(state, action)) {
 }
 ```
 
+## Lifecycle-aware host
+
+Demo host не является частью публичного navigation core. Он показывает минимальную Android-границу: `AppStore` атомарно публикует immutable `AppState` и transition metadata одним `AppStateFrame`, а `AppViewModel` удерживает store в lifecycle конкретной Activity.
+
+```kotlin
+private val appViewModel: AppViewModel by viewModels()
+
+setContent {
+    val frame by appViewModel.frames.collectAsStateWithLifecycle()
+
+    AnimatedNavigation(
+        navState = frame.appState.navState,
+        navTransition = frame.navigationTransition,
+        onNavigationAction = { action -> appViewModel.dispatch(action) },
+    )
+}
+```
+
+`dispatch` всегда применяет action к последнему committed state под одной короткой критической секцией. `Changed` публикует один согласованный frame, а `Unchanged` сохраняет тот же frame instance и не создаёт ложную анимацию. Transition — process-local metadata текущего frame, sticky до следующего `Changed`; он не является pending event и не восстанавливается из snapshot.
+
 ## Карта кода
 
-- [`AppState.kt`](app/src/main/java/com/shmakov/udf/AppState.kt) и [`UdfApp.kt`](app/src/main/java/com/shmakov/udf/UdfApp.kt) — текущий глобальный владелец state и начальное demo-состояние.
+- [`AppState.kt`](app/src/main/java/com/shmakov/udf/AppState.kt), [`AppStore.kt`](app/src/main/java/com/shmakov/udf/AppStore.kt) и [`AppViewModel.kt`](app/src/main/java/com/shmakov/udf/AppViewModel.kt) — immutable application state, linearizable store и Activity-scoped lifecycle owner.
+- [`UdfApp.kt`](app/src/main/java/com/shmakov/udf/UdfApp.kt) — только application initialization и logging; navigation state там не хранится.
 - [`navigation/`](app/src/main/java/com/shmakov/udf/navigation) — routes, back-stack entries, валидируемый navigation state, actions/reducer, snapshot/codec и screen abstractions.
 - [`AnimatedNavigation.kt`](app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt) — проекция стека, вложенный рендеринг, content transitions и modal bookkeeping.
 - [`BottomSheetLayout.kt`](app/src/main/java/com/shmakov/udf/composable/common/BottomSheetLayout.kt) — временное animation state bottom sheet.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.6.1'
     implementation 'androidx.activity:activity-compose:1.7.0'
 
     implementation 'androidx.compose.ui:ui'

--- a/app/src/main/java/com/shmakov/udf/AppStore.kt
+++ b/app/src/main/java/com/shmakov/udf/AppStore.kt
@@ -1,0 +1,54 @@
+package com.shmakov.udf
+
+import com.shmakov.udf.navigation.NavAction
+import com.shmakov.udf.navigation.NavReducer
+import com.shmakov.udf.navigation.NavReduction
+import com.shmakov.udf.navigation.NavTransitionIntent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * One observable application-state revision and the transient navigation intent that produced it.
+ *
+ * [navigationTransition] is render metadata. It is deliberately kept outside durable [AppState]
+ * and is replaced only when a navigation action changes state.
+ */
+internal data class AppStateFrame(
+    val appState: AppState,
+    val navigationTransition: NavTransitionIntent?,
+)
+
+/** A linearizable owner of application state transitions. */
+internal class AppStore(initialState: AppState) {
+    private val dispatchLock = Any()
+
+    private val mutableFrames = MutableStateFlow(
+        AppStateFrame(
+            appState = initialState,
+            navigationTransition = null,
+        ),
+    )
+
+    val frames: StateFlow<AppStateFrame> = mutableFrames.asStateFlow()
+
+    /**
+     * Applies [action] to the latest committed state.
+     *
+     * A private lock makes the read-reduce-publish operation atomic for callers from any thread.
+     * An unchanged reduction deliberately publishes no new frame.
+     */
+    fun dispatch(action: NavAction): NavReduction = synchronized(dispatchLock) {
+        val currentFrame = mutableFrames.value
+        val reduction = NavReducer.reduce(currentFrame.appState.navState, action)
+
+        if (reduction is NavReduction.Changed) {
+            mutableFrames.value = AppStateFrame(
+                appState = currentFrame.appState.copy(navState = reduction.state),
+                navigationTransition = reduction.transition,
+            )
+        }
+
+        reduction
+    }
+}

--- a/app/src/main/java/com/shmakov/udf/AppViewModel.kt
+++ b/app/src/main/java/com/shmakov/udf/AppViewModel.kt
@@ -1,0 +1,30 @@
+package com.shmakov.udf
+
+import androidx.lifecycle.ViewModel
+import com.shmakov.udf.navigation.Account
+import com.shmakov.udf.navigation.Accounts
+import com.shmakov.udf.navigation.Home
+import com.shmakov.udf.navigation.NavAction
+import com.shmakov.udf.navigation.NavReduction
+import com.shmakov.udf.navigation.NavState
+import kotlinx.coroutines.flow.StateFlow
+
+/** Activity-scoped lifecycle owner for the demo application state. */
+internal class AppViewModel(
+    initialState: AppState = demoAppState(),
+) : ViewModel() {
+    private val store = AppStore(initialState)
+
+    val frames: StateFlow<AppStateFrame> = store.frames
+
+    fun dispatch(action: NavAction): NavReduction = store.dispatch(action)
+}
+
+private fun demoAppState(): AppState = AppState(
+    navState = NavState.history(
+        root = Home,
+        Accounts,
+        Account(accountId = 1),
+    ),
+    showInPlace = false,
+)

--- a/app/src/main/java/com/shmakov/udf/MainActivity.kt
+++ b/app/src/main/java/com/shmakov/udf/MainActivity.kt
@@ -4,28 +4,30 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import com.shmakov.udf.UdfApp.Companion.appState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.shmakov.udf.composable.common.AnimatedNavigation
 import com.shmakov.udf.navigation.NavAction
 import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.ui.theme.UDFTheme
 
 class MainActivity : ComponentActivity() {
+    private val appViewModel: AppViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
-            val currentAppState = appState
-            val currentNavTransition = UdfApp.navTransition
+            val frame by appViewModel.frames.collectAsStateWithLifecycle()
 
-            BackHandler(enabled = currentAppState.navState.entries.size > 1) {
-                UdfApp.dispatchNavigation(NavAction.Pop)
+            BackHandler(enabled = frame.appState.navState.entries.size > 1) {
+                appViewModel.dispatch(NavAction.Pop)
             }
 
 
@@ -36,8 +38,9 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     AppContent(
-                        appState = currentAppState,
-                        navTransition = currentNavTransition,
+                        appState = frame.appState,
+                        navTransition = frame.navigationTransition,
+                        onNavigationAction = { action -> appViewModel.dispatch(action) },
                     )
                 }
             }
@@ -48,10 +51,12 @@ class MainActivity : ComponentActivity() {
     private fun AppContent(
         appState: AppState,
         navTransition: NavTransitionIntent?,
+        onNavigationAction: (NavAction) -> Unit,
     ) {
         AnimatedNavigation(
             navState = appState.navState,
             navTransition = navTransition,
+            onNavigationAction = onNavigationAction,
         )
     }
 }

--- a/app/src/main/java/com/shmakov/udf/UdfApp.kt
+++ b/app/src/main/java/com/shmakov/udf/UdfApp.kt
@@ -1,17 +1,8 @@
 package com.shmakov.udf
 
 import android.app.Application
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import com.shmakov.udf.navigation.*
 import timber.log.Timber
 import timber.log.Timber.DebugTree
-
-private data class AppFrame(
-    val state: AppState,
-    val navTransition: NavTransitionIntent?,
-)
 
 class UdfApp : Application() {
 
@@ -26,40 +17,4 @@ class UdfApp : Application() {
         })
     }
 
-    companion object {
-        private var frame by mutableStateOf(
-            NavState.history(
-                root = Home,
-                Accounts,
-                Account(accountId = 1),
-            ).let { initialNavState ->
-                AppFrame(
-                    state = AppState(
-                        navState = initialNavState,
-                        showInPlace = false,
-                    ),
-                    navTransition = null,
-                )
-            },
-        )
-
-        val appState: AppState
-            get() = frame.state
-
-        val navTransition: NavTransitionIntent?
-            get() = frame.navTransition
-
-        @JvmStatic
-        fun dispatchNavigation(action: NavAction): NavReduction {
-            val reduction = NavReducer.reduce(frame.state.navState, action)
-            if (reduction is NavReduction.Changed) {
-                frame = AppFrame(
-                    state = frame.state.copy(navState = reduction.state),
-                    navTransition = reduction.transition,
-                )
-            }
-
-            return reduction
-        }
-    }
 }

--- a/app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import com.shmakov.udf.UdfApp
 import com.shmakov.udf.composable.screen.AccountBottomSheet
 import com.shmakov.udf.composable.screen.AccountDetailsScreen
 import com.shmakov.udf.composable.screen.AccountsScreen
@@ -44,11 +43,13 @@ import java.util.concurrent.atomic.AtomicReference
 fun AnimatedNavigation(
     navState: NavState,
     navTransition: NavTransitionIntent?,
+    onNavigationAction: (NavAction) -> Unit,
 ) {
     AnimatedNavigation(
         entries = navState.entries,
         into = RenderSlot.Root,
         navTransition = navTransition,
+        onNavigationAction = onNavigationAction,
     )
 }
 
@@ -57,6 +58,7 @@ internal fun AnimatedNavigation(
     entries: List<BackStackEntry>,
     into: RenderSlot,
     navTransition: NavTransitionIntent?,
+    onNavigationAction: (NavAction) -> Unit,
 ) {
     val rootEntry = entries.firstOrNull() ?: return
 
@@ -133,6 +135,7 @@ internal fun AnimatedNavigation(
         getContentScreen(entry).Content(
             nestedEntries = nestedEntries,
             navTransition = navTransition,
+            onNavigationAction = onNavigationAction,
         )
 
         val modalEntries = entries
@@ -182,8 +185,9 @@ internal fun AnimatedNavigation(
                             items.filterNot { it.id == item.id }
                         }
 
-                        UdfApp.dispatchNavigation(NavAction.DismissModal(item.id))
+                        onNavigationAction(NavAction.dismissModal(item.id))
                     },
+                    onNavigationAction = onNavigationAction,
                 )
             }
         }

--- a/app/src/main/java/com/shmakov/udf/composable/content/AccountBottomSheetContent.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/content/AccountBottomSheetContent.kt
@@ -6,41 +6,23 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
-import com.shmakov.udf.UdfApp
-import com.shmakov.udf.navigation.Account
-import com.shmakov.udf.navigation.AccountDetails
-import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavAction
 
 @Composable
 fun ColumnScope.AccountBottomSheetContent(
-    currentEntry: BackStackEntry,
     accountId: Int,
+    onNextAccount: (Int) -> Unit,
+    onDetailsRequested: () -> Unit,
 ) {
     if (accountId < 9) {
         Button(
-            onClick = {
-                UdfApp.dispatchNavigation(
-                    NavAction.push(
-                        expectedTopId = currentEntry.id,
-                        route = Account(accountId = accountId + 1),
-                    ),
-                )
-            },
+            onClick = { onNextAccount(accountId + 1) },
         ) {
             Text(text = "Go to Account #${accountId + 1}")
         }
     }
 
     Button(
-        onClick = {
-            UdfApp.dispatchNavigation(
-                NavAction.push(
-                    expectedTopId = currentEntry.id,
-                    route = AccountDetails(accountId = accountId),
-                ),
-            )
-        },
+        onClick = onDetailsRequested,
         modifier = Modifier
             .align(CenterHorizontally)
     ) {

--- a/app/src/main/java/com/shmakov/udf/composable/content/AccountsScreenContent.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/content/AccountsScreenContent.kt
@@ -8,13 +8,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.shmakov.udf.UdfApp
-import com.shmakov.udf.navigation.Account
-import com.shmakov.udf.navigation.BackStackEntry
-import com.shmakov.udf.navigation.NavAction
 
 @Composable
-fun AccountsScreenContent(currentEntry: BackStackEntry) {
+fun AccountsScreenContent(
+    onAccountSelected: (Int) -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -25,18 +23,9 @@ fun AccountsScreenContent(currentEntry: BackStackEntry) {
         )
 
         for (i in 1..10) {
-            Button(onClick = { navigateTo(currentEntry, i) }) {
+            Button(onClick = { onAccountSelected(i) }) {
                 Text(text = "Go to Account $i")
             }
         }
     }
-}
-
-private fun navigateTo(currentEntry: BackStackEntry, id: Int) {
-    UdfApp.dispatchNavigation(
-        NavAction.push(
-            expectedTopId = currentEntry.id,
-            route = Account(accountId = id),
-        ),
-    )
 }

--- a/app/src/main/java/com/shmakov/udf/composable/content/HomeScreenContent.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/content/HomeScreenContent.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
-import com.shmakov.udf.UdfApp
 import com.shmakov.udf.composable.common.AnimatedNavigation
 import com.shmakov.udf.navigation.*
 
@@ -20,6 +19,8 @@ fun HomeScreenContent(
     currentEntry: BackStackEntry,
     nestedEntries: List<BackStackEntry>,
     navTransition: NavTransitionIntent?,
+    onDestinationSelected: (ContentRoute) -> Unit,
+    onNavigationAction: (NavAction) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -34,11 +35,11 @@ fun HomeScreenContent(
 
         if (isLandscape) {
             Row {
-                Buttons(currentEntry = currentEntry)
+                Buttons(onDestinationSelected = onDestinationSelected)
             }
         } else {
             Column {
-                Buttons(currentEntry = currentEntry)
+                Buttons(onDestinationSelected = onDestinationSelected)
             }
         }
 
@@ -47,6 +48,7 @@ fun HomeScreenContent(
                 entries = nestedEntries,
                 into = RenderSlot.Nested(currentEntry.id),
                 navTransition = navTransition,
+                onNavigationAction = onNavigationAction,
             )
         }
     }
@@ -54,31 +56,19 @@ fun HomeScreenContent(
 
 @Composable
 fun Buttons(
-    currentEntry: BackStackEntry,
+    onDestinationSelected: (ContentRoute) -> Unit,
 ) {
-    Button(onClick = { navigateTo(currentEntry, Accounts) }) {
+    Button(onClick = { onDestinationSelected(Accounts) }) {
         Text(text = "Go to Accounts")
     }
 
     Button(
-        onClick = { navigateTo(currentEntry, Transactions) },
+        onClick = { onDestinationSelected(Transactions) },
     ) {
         Text(text = "Go to Transactions")
     }
 
-    Button(onClick = { navigateTo(currentEntry, Cards) }) {
+    Button(onClick = { onDestinationSelected(Cards) }) {
         Text(text = "Go to Cards")
     }
-}
-
-private fun navigateTo(
-    currentEntry: BackStackEntry,
-    targetRoute: ContentRoute,
-) {
-    UdfApp.dispatchNavigation(
-        NavAction.navigateFrom(
-            sourceId = currentEntry.id,
-            route = targetRoute,
-        ),
-    )
 }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/AccountBottomSheet.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/AccountBottomSheet.kt
@@ -4,20 +4,39 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
 import com.shmakov.udf.composable.content.AccountBottomSheetContent
 import com.shmakov.udf.navigation.Account
+import com.shmakov.udf.navigation.AccountDetails
 import com.shmakov.udf.navigation.BackStackEntry
 import com.shmakov.udf.navigation.BottomSheet
+import com.shmakov.udf.navigation.NavAction
 
 class AccountBottomSheet(
     override val entry: BackStackEntry,
 ) : BottomSheet(entry) {
 
     @Composable
-    override fun ColumnScope.Content() {
+    override fun ColumnScope.Content(
+        onNavigationAction: (NavAction) -> Unit,
+    ) {
         val route = entry.route as Account
 
         AccountBottomSheetContent(
-            currentEntry = entry,
             accountId = route.accountId,
+            onNextAccount = { nextAccountId ->
+                onNavigationAction(
+                    NavAction.push(
+                        expectedTopId = entry.id,
+                        route = Account(accountId = nextAccountId),
+                    ),
+                )
+            },
+            onDetailsRequested = {
+                onNavigationAction(
+                    NavAction.push(
+                        expectedTopId = entry.id,
+                        route = AccountDetails(accountId = route.accountId),
+                    ),
+                )
+            },
         )
     }
 }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/AccountDetailsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/AccountDetailsScreen.kt
@@ -12,6 +12,7 @@ class AccountDetailsScreen(
     override fun Content(
         nestedEntries: List<BackStackEntry>,
         navTransition: NavTransitionIntent?,
+        onNavigationAction: (NavAction) -> Unit,
     ) {
         val route = entry.route as AccountDetails
 

--- a/app/src/main/java/com/shmakov/udf/composable/screen/AccountsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/AccountsScreen.kt
@@ -2,7 +2,9 @@ package com.shmakov.udf.composable.screen
 
 import androidx.compose.runtime.Composable
 import com.shmakov.udf.composable.content.AccountsScreenContent
+import com.shmakov.udf.navigation.Account
 import com.shmakov.udf.navigation.BackStackEntry
+import com.shmakov.udf.navigation.NavAction
 import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.Screen
 
@@ -14,7 +16,17 @@ class AccountsScreen(
     override fun Content(
         nestedEntries: List<BackStackEntry>,
         navTransition: NavTransitionIntent?,
+        onNavigationAction: (NavAction) -> Unit,
     ) {
-        AccountsScreenContent(currentEntry = entry)
+        AccountsScreenContent(
+            onAccountSelected = { accountId ->
+                onNavigationAction(
+                    NavAction.push(
+                        expectedTopId = entry.id,
+                        route = Account(accountId = accountId),
+                    ),
+                )
+            },
+        )
     }
 }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/CardsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/CardsScreen.kt
@@ -3,6 +3,7 @@ package com.shmakov.udf.composable.screen
 import androidx.compose.runtime.Composable
 import com.shmakov.udf.composable.content.CardsScreenContent
 import com.shmakov.udf.navigation.BackStackEntry
+import com.shmakov.udf.navigation.NavAction
 import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.Screen
 
@@ -14,6 +15,7 @@ class CardsScreen(
     override fun Content(
         nestedEntries: List<BackStackEntry>,
         navTransition: NavTransitionIntent?,
+        onNavigationAction: (NavAction) -> Unit,
     ) {
         CardsScreenContent()
     }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/HomeScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/HomeScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalConfiguration
 import com.shmakov.udf.composable.content.HomeScreenContent
 import com.shmakov.udf.navigation.BackStackEntry
+import com.shmakov.udf.navigation.ContentRoute
+import com.shmakov.udf.navigation.NavAction
 import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.RenderSlot
 import com.shmakov.udf.navigation.Screen
@@ -33,11 +35,21 @@ class HomeScreen(
     override fun Content(
         nestedEntries: List<BackStackEntry>,
         navTransition: NavTransitionIntent?,
+        onNavigationAction: (NavAction) -> Unit,
     ) {
         HomeScreenContent(
             currentEntry = entry,
             nestedEntries = nestedEntries,
             navTransition = navTransition,
+            onDestinationSelected = { destination: ContentRoute ->
+                onNavigationAction(
+                    NavAction.navigateFrom(
+                        sourceId = entry.id,
+                        route = destination,
+                    ),
+                )
+            },
+            onNavigationAction = onNavigationAction,
         )
     }
 }

--- a/app/src/main/java/com/shmakov/udf/composable/screen/TransactionsScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/composable/screen/TransactionsScreen.kt
@@ -3,6 +3,7 @@ package com.shmakov.udf.composable.screen
 import androidx.compose.runtime.Composable
 import com.shmakov.udf.composable.content.TransactionsScreenContent
 import com.shmakov.udf.navigation.BackStackEntry
+import com.shmakov.udf.navigation.NavAction
 import com.shmakov.udf.navigation.NavTransitionIntent
 import com.shmakov.udf.navigation.Screen
 
@@ -14,6 +15,7 @@ class TransactionsScreen(
     override fun Content(
         nestedEntries: List<BackStackEntry>,
         navTransition: NavTransitionIntent?,
+        onNavigationAction: (NavAction) -> Unit,
     ) {
         TransactionsScreenContent()
     }

--- a/app/src/main/java/com/shmakov/udf/navigation/BottomSheet.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/BottomSheet.kt
@@ -11,16 +11,19 @@ abstract class BottomSheet(
     @Composable
     override fun ModalContent(
         targetState: ModalScreenState,
-        onHide: () -> Unit
+        onHide: () -> Unit,
+        onNavigationAction: (NavAction) -> Unit,
     ) {
         BottomSheetLayout(
             targetState = targetState,
             onHide = onHide,
         ) {
-            Content()
+            Content(onNavigationAction = onNavigationAction)
         }
     }
 
     @Composable
-    abstract fun ColumnScope.Content()
+    abstract fun ColumnScope.Content(
+        onNavigationAction: (NavAction) -> Unit,
+    )
 }

--- a/app/src/main/java/com/shmakov/udf/navigation/ModalScreen.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/ModalScreen.kt
@@ -10,6 +10,7 @@ abstract class ModalScreen(
     abstract fun ModalContent(
         targetState: ModalScreenState,
         onHide: () -> Unit,
+        onNavigationAction: (NavAction) -> Unit,
     )
 }
 

--- a/app/src/main/java/com/shmakov/udf/navigation/Screen.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/Screen.kt
@@ -18,6 +18,7 @@ abstract class Screen(
     abstract fun Content(
         nestedEntries: List<BackStackEntry>,
         navTransition: NavTransitionIntent?,
+        onNavigationAction: (NavAction) -> Unit,
     )
 }
 

--- a/app/src/test/java/com/shmakov/udf/AppStoreContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/AppStoreContractTest.kt
@@ -1,0 +1,388 @@
+package com.shmakov.udf
+
+import com.shmakov.udf.navigation.Account
+import com.shmakov.udf.navigation.AccountDetails
+import com.shmakov.udf.navigation.Accounts
+import com.shmakov.udf.navigation.BackStackEntry
+import com.shmakov.udf.navigation.Cards
+import com.shmakov.udf.navigation.ContentRoute
+import com.shmakov.udf.navigation.EntryId
+import com.shmakov.udf.navigation.Home
+import com.shmakov.udf.navigation.NavAction
+import com.shmakov.udf.navigation.NavReduction
+import com.shmakov.udf.navigation.NavState
+import com.shmakov.udf.navigation.NavStateCreationResult
+import com.shmakov.udf.navigation.NavTransitionIntent
+import com.shmakov.udf.navigation.NavUnchangedReason
+import com.shmakov.udf.navigation.Route
+import com.shmakov.udf.navigation.Transactions
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppStoreContractTest {
+
+    @Test
+    fun `initial frame exposes the supplied immutable app state`() {
+        val initial = appState(entry("home", Home), showInPlace = true)
+        val store = AppStore(initial)
+
+        val exposedFrames: StateFlow<AppStateFrame> = store.frames
+        val frame = exposedFrames.value
+
+        assertSame(initial, frame.appState)
+        assertTrue(frame.appState.showInPlace)
+        assertNull(frame.navigationTransition)
+        assertFalse(exposedFrames is MutableStateFlow<*>)
+    }
+
+    @Test
+    fun `changed reduction publishes state and transition in one frame`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val store = AppStore(appState(home))
+
+        val reduction = changed(
+            store.dispatch(NavAction.Push(home.id, accounts)),
+        )
+        val frame = store.frames.value
+
+        assertSame(reduction.state, frame.appState.navState)
+        assertEquals(listOf(home, accounts), frame.appState.navState.entries)
+        assertEquals(reduction.transition, frame.navigationTransition)
+        assertEquals(
+            NavTransitionIntent.Pushed(home.id, accounts.id),
+            frame.navigationTransition,
+        )
+    }
+
+    @Test
+    fun `unchanged reduction keeps the exact observable frame`() {
+        val store = AppStore(appState(entry("home", Home)))
+        val before = store.frames.value
+
+        val reduction = unchanged(store.dispatch(NavAction.Pop))
+
+        assertEquals(NavUnchangedReason.RootProtected, reduction.reason)
+        assertSame(before.appState.navState, reduction.state)
+        assertSame(before, store.frames.value)
+    }
+
+    @Test
+    fun `navigation changes preserve unrelated app state`() {
+        val home = entry("home", Home)
+        val store = AppStore(appState(home, showInPlace = true))
+
+        changed(
+            store.dispatch(
+                NavAction.Push(home.id, entry("accounts", Accounts)),
+            ),
+        )
+
+        assertTrue(store.frames.value.appState.showInPlace)
+    }
+
+    @Test
+    fun `representative sequence always reduces the latest committed state`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(42))
+        val store = AppStore(appState(home, showInPlace = true))
+
+        val pushAccounts = changed(
+            store.dispatch(NavAction.Push(home.id, accounts)),
+        )
+        assertEquals(pushAccounts.transition, store.frames.value.navigationTransition)
+
+        val pushAccount = changed(
+            store.dispatch(NavAction.Push(accounts.id, account)),
+        )
+        assertEquals(
+            listOf(home, accounts, account),
+            store.frames.value.appState.navState.entries,
+        )
+        assertEquals(pushAccount.transition, store.frames.value.navigationTransition)
+
+        val dismissAccount = changed(
+            store.dispatch(NavAction.DismissModal(account.id)),
+        )
+        assertEquals(
+            listOf(home, accounts),
+            store.frames.value.appState.navState.entries,
+        )
+        assertEquals(dismissAccount.transition, store.frames.value.navigationTransition)
+
+        val popAccounts = changed(store.dispatch(NavAction.Pop))
+        assertEquals(listOf(home), store.frames.value.appState.navState.entries)
+        assertEquals(popAccounts.transition, store.frames.value.navigationTransition)
+        assertTrue(store.frames.value.appState.showInPlace)
+    }
+
+    @Test
+    fun `stale guarded push is a no-op and does not replace transition metadata`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val store = AppStore(appState(home))
+        val staleAction = NavAction.Push(
+            expectedTopId = home.id,
+            entry = entry("stale-details", AccountDetails(7)),
+        )
+
+        changed(store.dispatch(NavAction.Push(home.id, accounts)))
+        val beforeStaleAction = store.frames.value
+        val result = unchanged(store.dispatch(staleAction))
+
+        assertEquals(
+            NavUnchangedReason.SourceIsNotTop(home.id, accounts.id),
+            result.reason,
+        )
+        assertSame(beforeStaleAction, store.frames.value)
+        assertEquals(
+            NavTransitionIntent.Pushed(home.id, accounts.id),
+            store.frames.value.navigationTransition,
+        )
+    }
+
+    @Test
+    fun `stale branch callback after logout cannot replace the new history`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val store = AppStore(appState(home, accounts))
+        val staleAction = NavAction.NavigateFrom(
+            sourceId = home.id,
+            entry = entry("cards", Cards),
+        )
+        val signedOut = navState(entry("signed-out", SignedOut))
+
+        changed(store.dispatch(NavAction.ReplaceHistory(signedOut)))
+        val logoutFrame = store.frames.value
+        val result = unchanged(store.dispatch(staleAction))
+
+        assertEquals(NavUnchangedReason.EntryNotFound(home.id), result.reason)
+        assertSame(logoutFrame, store.frames.value)
+        assertSame(signedOut, store.frames.value.appState.navState)
+    }
+
+    @Test
+    fun `stale modal completion addresses identity and leaves duplicate route occurrence`() {
+        val home = entry("home", Home)
+        val first = entry("account-1", Account(42))
+        val second = entry("account-2", Account(42))
+        val store = AppStore(appState(home, first, second))
+
+        changed(store.dispatch(NavAction.DismissModal(first.id)))
+        assertEquals(
+            listOf(home, second),
+            store.frames.value.appState.navState.entries,
+        )
+
+        val afterDismiss = store.frames.value
+        val staleCompletion = unchanged(
+            store.dispatch(NavAction.DismissModal(first.id)),
+        )
+
+        assertEquals(NavUnchangedReason.EntryNotFound(first.id), staleCompletion.reason)
+        assertSame(afterDismiss, store.frames.value)
+        assertEquals(second.id, store.frames.value.appState.navState.top.id)
+    }
+
+    @Test
+    fun `replace history publishes one atomic frame`() {
+        val home = entry("home", Home)
+        val store = AppStore(
+            appState(
+                home,
+                entry("accounts", Accounts),
+                entry("account", Account(1)),
+                showInPlace = true,
+            ),
+        )
+        val target = navState(
+            entry("deep-home", Home),
+            entry("transactions", Transactions),
+        )
+
+        runBlocking {
+            val observedFrames = async(start = CoroutineStart.UNDISPATCHED) {
+                store.frames.take(2).toList()
+            }
+
+            val reduction = changed(
+                store.dispatch(NavAction.ReplaceHistory(target)),
+            )
+            val frames = withTimeout(2_000) { observedFrames.await() }
+
+            assertEquals(2, frames.size)
+            assertEquals(3, frames.first().appState.navState.entries.size)
+            assertSame(target, frames.last().appState.navState)
+            assertTrue(frames.last().appState.showInPlace)
+            assertEquals(reduction.transition, frames.last().navigationTransition)
+            assertEquals(
+                NavTransitionIntent.HistoryReplaced(
+                    previousTopEntryId = EntryId("account"),
+                    targetTopEntryId = EntryId("transactions"),
+                ),
+                frames.last().navigationTransition,
+            )
+        }
+    }
+
+    @Test
+    fun `independent stores never share mutable state`() {
+        val home = entry("home", Home)
+        val initial = appState(home)
+        val first = AppStore(initial)
+        val second = AppStore(initial)
+
+        changed(
+            first.dispatch(
+                NavAction.Push(home.id, entry("accounts", Accounts)),
+            ),
+        )
+
+        assertEquals(2, first.frames.value.appState.navState.entries.size)
+        assertSame(initial, second.frames.value.appState)
+        assertEquals(1, second.frames.value.appState.navState.entries.size)
+        assertNull(second.frames.value.navigationTransition)
+    }
+
+    @Test
+    fun `concurrent guarded pushes serialize and commit exactly one child`() {
+        val home = entry("home", Home)
+        val store = AppStore(appState(home))
+        val actions = (1..32).map { index ->
+            NavAction.Push(
+                expectedTopId = home.id,
+                entry = entry("accounts-$index", Accounts),
+            )
+        }
+
+        val reductions = dispatchConcurrently(store, actions)
+        val changes = reductions.filterIsInstance<NavReduction.Changed>()
+        val unchanged = reductions.filterIsInstance<NavReduction.Unchanged>()
+
+        assertEquals(1, changes.size)
+        assertEquals(actions.size - 1, unchanged.size)
+        assertTrue(
+            unchanged.all { result ->
+                result.reason == NavUnchangedReason.SourceIsNotTop(
+                    expectedTopId = home.id,
+                    actualTopId = store.frames.value.appState.navState.top.id,
+                )
+            },
+        )
+        assertEquals(2, store.frames.value.appState.navState.entries.size)
+        assertTrue(
+            actions.any { action ->
+                action.entry.id == store.frames.value.appState.navState.top.id
+            },
+        )
+        assertEquals(changes.single().transition, store.frames.value.navigationTransition)
+    }
+
+    @Test
+    fun `concurrent pops drain the history once and stop at root`() {
+        val home = entry("home", Home)
+        val children = (1..32).map { index -> entry("entry-$index", Accounts) }
+        val store = AppStore(
+            appState(
+                home,
+                *children.toTypedArray(),
+                showInPlace = true,
+            ),
+        )
+
+        val reductions = dispatchConcurrently(
+            store = store,
+            actions = List(64) { NavAction.Pop },
+        )
+
+        assertEquals(32, reductions.count { it is NavReduction.Changed })
+        assertEquals(
+            32,
+            reductions.count { result ->
+                result is NavReduction.Unchanged &&
+                    result.reason == NavUnchangedReason.RootProtected
+            },
+        )
+        assertEquals(listOf(home), store.frames.value.appState.navState.entries)
+        assertTrue(store.frames.value.appState.showInPlace)
+        assertEquals(
+            NavTransitionIntent.Popped(
+                removedEntryId = children.first().id,
+                revealedEntryId = home.id,
+            ),
+            store.frames.value.navigationTransition,
+        )
+    }
+
+    private fun dispatchConcurrently(
+        store: AppStore,
+        actions: List<NavAction>,
+    ): List<NavReduction> {
+        val executor = Executors.newFixedThreadPool(8)
+        val start = CountDownLatch(1)
+        return try {
+            val futures = actions.map { action ->
+                executor.submit<NavReduction> {
+                    assertTrue(start.await(5, TimeUnit.SECONDS))
+                    store.dispatch(action)
+                }
+            }
+
+            start.countDown()
+            futures.map { future -> future.get(5, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    private fun changed(result: NavReduction): NavReduction.Changed = when (result) {
+        is NavReduction.Changed -> result
+        is NavReduction.Unchanged -> throw AssertionError(
+            "Expected state change, got ${result.reason}",
+        )
+    }
+
+    private fun unchanged(result: NavReduction): NavReduction.Unchanged = when (result) {
+        is NavReduction.Changed -> throw AssertionError(
+            "Expected no-op, got ${result.transition}",
+        )
+        is NavReduction.Unchanged -> result
+    }
+
+    private fun appState(
+        vararg entries: BackStackEntry,
+        showInPlace: Boolean = false,
+    ): AppState = AppState(
+        navState = navState(*entries),
+        showInPlace = showInPlace,
+    )
+
+    private fun navState(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> throw AssertionError(
+                "Invalid test fixture: ${result.problems}",
+            )
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        BackStackEntry(EntryId(id), route)
+
+    private object SignedOut : ContentRoute
+}

--- a/app/src/test/java/com/shmakov/udf/AppViewModelContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/AppViewModelContractTest.kt
@@ -1,0 +1,101 @@
+package com.shmakov.udf
+
+import androidx.lifecycle.ViewModel
+import com.shmakov.udf.navigation.Account
+import com.shmakov.udf.navigation.Accounts
+import com.shmakov.udf.navigation.BackStackEntry
+import com.shmakov.udf.navigation.EntryId
+import com.shmakov.udf.navigation.Home
+import com.shmakov.udf.navigation.NavAction
+import com.shmakov.udf.navigation.NavReduction
+import com.shmakov.udf.navigation.NavState
+import com.shmakov.udf.navigation.NavStateCreationResult
+import com.shmakov.udf.navigation.NavTransitionIntent
+import com.shmakov.udf.navigation.Route
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppViewModelContractTest {
+
+    @Test
+    fun `view model is a lifecycle owner that delegates observable state and dispatch`() {
+        val home = entry("home", Home)
+        val initial = appState(home, showInPlace = true)
+        val viewModel = AppViewModel(initial)
+
+        val lifecycleViewModel: ViewModel = viewModel
+        val exposedFrames: StateFlow<AppStateFrame> = viewModel.frames
+
+        assertSame(viewModel, lifecycleViewModel)
+        assertSame(initial, exposedFrames.value.appState)
+
+        val accounts = entry("accounts", Accounts)
+        val reduction = viewModel.dispatch(NavAction.Push(home.id, accounts))
+        assertTrue(reduction is NavReduction.Changed)
+        reduction as NavReduction.Changed
+
+        assertSame(reduction.state, viewModel.frames.value.appState.navState)
+        assertEquals(reduction.transition, viewModel.frames.value.navigationTransition)
+        assertTrue(viewModel.frames.value.appState.showInPlace)
+    }
+
+    @Test
+    fun `view model instances own independent stores`() {
+        val home = entry("home", Home)
+        val initial = appState(home)
+        val first = AppViewModel(initial)
+        val second = AppViewModel(initial)
+
+        val accounts = entry("accounts", Accounts)
+        first.dispatch(NavAction.Push(home.id, accounts))
+
+        assertEquals(2, first.frames.value.appState.navState.entries.size)
+        assertSame(initial, second.frames.value.appState)
+        assertEquals(1, second.frames.value.appState.navState.entries.size)
+        assertNull(second.frames.value.navigationTransition)
+    }
+
+    @Test
+    fun `default view model publishes the demo state`() {
+        val viewModel = AppViewModel()
+        val frame = viewModel.frames.value
+
+        assertEquals(
+            listOf(Home, Accounts, Account(1)),
+            frame.appState.navState.entries.map(BackStackEntry::route),
+        )
+        assertEquals(
+            frame.appState.navState.entries.size,
+            frame.appState.navState.entries.map(BackStackEntry::id).toSet().size,
+        )
+        assertTrue(
+            frame.appState.navState.entries.all { entry -> entry.id.value.isNotBlank() },
+        )
+        assertFalse(frame.appState.showInPlace)
+        assertNull(frame.navigationTransition)
+    }
+
+    private fun appState(
+        vararg entries: BackStackEntry,
+        showInPlace: Boolean = false,
+    ): AppState = AppState(
+        navState = navState(*entries),
+        showInPlace = showInPlace,
+    )
+
+    private fun navState(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> throw AssertionError(
+                "Invalid test fixture: ${result.problems}",
+            )
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        BackStackEntry(EntryId(id), route)
+}

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -36,7 +36,7 @@
 
 Navigation input представлен закрытым набором typed `NavAction`, а `NavReducer.reduce(state, action)` является чистой Kotlin-функцией. Результат — `NavReduction.Changed(state, transition)` либо `NavReduction.Unchanged(state, reason)`. Action factories материализуют identity новых entries до reduction, поэтому reducer не генерирует случайные значения.
 
-`NavTransitionIntent` описывает только что совершившийся Push, Pop, branch replacement, modal dismiss или full-history replacement. Он возвращается отдельно от durable `NavState` и не попадает в snapshot. Временный `UdfApp` удерживает последний intent рядом с `AppState` в process-local render envelope до следующего `Changed`, а renderer использует его для выбора legacy motion. Одноразовое consumption, lifecycle-aware store и настраиваемая animation policy появятся отдельными инкрементами.
+`NavTransitionIntent` описывает только что совершившийся Push, Pop, branch replacement, modal dismiss или full-history replacement. Он возвращается отдельно от durable `NavState` и не попадает в snapshot. Demo-specific `AppStore` атомарно связывает immutable `AppState` и последний intent в process-local `AppStateFrame`; `AppViewModel` удерживает store в lifecycle конкретной Activity. Intent остаётся metadata текущего frame до следующего `Changed`, а renderer использует его для выбора legacy motion. Одноразовое consumption и настраиваемая animation policy появятся отдельными инкрементами.
 
 `AnimatedNavigation(navState, navTransition)` сворачивает entries и выбирает content для конкретного внутреннего render slot. `Screen.whereToShowChild` может вернуть другой слот, поэтому одна логическая история имеет разные физические layout-проекции.
 
@@ -54,6 +54,7 @@ Navigation input представлен закрытым набором typed `N
 - **Navigation state** — упорядоченная логическая история entries.
 - **Action** — событие пользователя, системы, lifecycle или завершения presentation-анимации, отправленное владельцу state.
 - **Reduction** — результат чистого применения `NavAction`: изменённый state с transient transition intent либо тот же state с typed причиной no-op.
+- **State frame** — атомарно опубликованная пара immutable `AppState` и process-local transition metadata; это observable runtime envelope, а не persistence format.
 - **Transition intent** — эфемерное описание совершившегося navigation transition; оно не является частью `NavState` и не восстанавливается из snapshot.
 - **Projection** — детерминированное преобразование navigation state и конфигурации окна в видимое размещение.
 - **Navigation tree** — root content, nested slots и modal layers, которые должен отрисовать Compose.
@@ -98,7 +99,7 @@ Route отвечает на вопрос «куда», entry — «какое и
 - branch replacement полезен, когда родитель остаётся видимым и выбирает другого ребёнка;
 - удалённый modal entry иногда нужно временно удерживать в presentation state до завершения exit-анимации.
 
-Reducer contract покрывает эталонные state transitions и подключён к одной временной runtime boundary, но lifecycle-aware store, чистая projection, renderer races, lifecycle restoration и сложные анимации ещё не доказаны end-to-end.
+Reducer contract покрывает эталонные state transitions и подключён к lifecycle-aware owner. Store contracts доказывают атомарные frames, stale callbacks, независимых owners и сериализацию concurrent actions, но чистая projection, renderer races, process restoration и сложные анимации ещё не доказаны end-to-end.
 
 ## Текущий data flow
 
@@ -111,25 +112,27 @@ NavState + NavAction
      | NavReduction.Unchanged(sameState, reason)
 ```
 
-В demo runtime все navigation mutations уже проходят через одну boundary:
+В demo runtime все navigation mutations проходят через один Activity-scoped owner:
 
 ```text
-UI callback -> UdfApp.dispatchNavigation(NavAction)
-            -> NavReducer
-            -> AppState + transient NavTransitionIntent
-            -> Compose rendering
+UI / renderer callback -> AppViewModel.dispatch(NavAction)
+                       -> linearizable AppStore
+                       -> NavReducer
+                       -> AppStateFrame(AppState, NavTransitionIntent?)
+                       -> lifecycle-aware Compose collection
+                       -> Compose rendering
 ```
 
-`appState` доступен UI только для чтения; `MainActivity`, demo composables и modal callback больше не собирают history вручную. Эта boundary всё ещё process-global и не lifecycle-aware; effect boundary, чистая projection и настраиваемая reducer-to-renderer animation policy пока отсутствуют.
+`MainActivity` получает read-only `StateFlow<AppStateFrame>` через `collectAsStateWithLifecycle`. Screen adapters создают typed actions, leaf composables получают semantic callbacks, а renderer только сообщает modal completion. `UdfApp` больше не хранит navigation state. Чистая projection, process restoration и настраиваемая reducer-to-renderer animation policy пока отсутствуют.
 
 ## Известные риски и незавершённая работа
 
 ### Владение state
 
-- `UdfApp` всё ещё владеет глобальным для процесса Compose frame, хотя `appState` снаружи доступен только для чтения.
-- UI и renderer отправляют typed actions в `dispatchNavigation`, но эта временная boundary не привязана к lifecycle конкретной Activity.
-- обычная Activity recreation может случайно сохранить state, но после process death восстанавливается hard-coded начальная история.
-- несколько Activity или task instances разделяли бы один navigation state.
+- `AppViewModel` является lifecycle owner одного экземпляра Activity; configuration recreation сохраняет тот же store.
+- разные Activity/ViewModel instances имеют независимые stores и больше не разделяют process-global navigation state.
+- `AppStore` публикует state только через read-only `StateFlow`, а все изменения проходят через синхронный `dispatch` и reducer.
+- после process death всё ещё создаётся hard-coded начальная история: snapshot пока не подключён к `SavedStateHandle`.
 
 ### Модель и идентичность
 
@@ -158,11 +161,11 @@ UI callback -> UdfApp.dispatchNavigation(NavAction)
 
 - `NavState` и `NavReducer` защищают root независимо от устаревшего состояния UI callback.
 - pure reducer детерминированно останавливает быстрые Pop на root и возвращает typed no-op для stale IDs.
-- demo callbacks dispatch-ят actions через одну process-global boundary; lifecycle и конкурентное владение будут формализованы единым store.
+- store сериализует быстрые и concurrent actions одной приватной критической секцией; stale callbacks всегда редуцируются относительно последнего committed frame.
 
 ### Надёжность и поддержка
 
-- model, identity, snapshot и reducer покрыты pure Kotlin contract tests, но projection-, lifecycle- и UI navigation tests ещё отсутствуют;
+- model, identity, snapshot, reducer и store serialization покрыты JVM contract tests, но projection- и lifecycle-restoration tests ещё отсутствуют;
 - Android/Compose toolchain отражает исходный прототип и должен обновляться только после появления safety net;
 - demo UI смешивает Material 2 и Material 3.
 
@@ -176,7 +179,7 @@ UI/System event
     -> state owner
     -> NavReducer.reduce(previous NavState, NavAction)
     -> NavReduction
-    -> new AppState + transient NavTransitionIntent
+    -> AppStateFrame(AppState, transient NavTransitionIntent?)
     -> project(NavState, WindowConfiguration)
     -> NavigationTree(root, nested slots, modals)
     -> Compose rendering
@@ -209,7 +212,7 @@ fun project(
 ): NavigationTree
 ```
 
-Route, entry identity, validated `NavState`, primitive snapshot и pure navigation reducer уже реализуют deterministic core этой схемы. Временная runtime boundary передаёт transition intent renderer-у; lifecycle-aware state owner, чистая projection и настраиваемая animation policy ещё не реализованы.
+Route, entry identity, validated `NavState`, primitive snapshot, pure reducer и lifecycle-aware state owner уже реализуют deterministic state boundary этой схемы. `AppStateFrame` согласованно передаёт state и transition intent renderer-у; чистая projection, process restoration и настраиваемая animation policy ещё не реализованы.
 
 ## Обязательные инварианты
 
@@ -279,6 +282,8 @@ Route, entry identity, validated `NavState`, primitive snapshot и pure navigati
 ## Важные файлы
 
 - `app/src/main/java/com/shmakov/udf/AppState.kt`
+- `app/src/main/java/com/shmakov/udf/AppStore.kt`
+- `app/src/main/java/com/shmakov/udf/AppViewModel.kt`
 - `app/src/main/java/com/shmakov/udf/UdfApp.kt`
 - `app/src/main/java/com/shmakov/udf/MainActivity.kt`
 - `app/src/main/java/com/shmakov/udf/navigation/Route.kt`


### PR DESCRIPTION
Closes #11

## Что изменено

- Добавлен demo-internal pure Kotlin `AppStore`: он публикует read-only `StateFlow<AppStateFrame>` и линейно сериализует read → reduce → publish через private lock.
- `AppStateFrame` атомарно связывает immutable `AppState` с process-local `NavTransitionIntent`; `Unchanged` не публикует новый frame.
- Activity-scoped `AppViewModel` стал lifecycle owner. `MainActivity` использует `by viewModels()` и `collectAsStateWithLifecycle()`; `UdfApp` оставлен только для initialization/logging.
- Android Back, screen adapters и renderer отправляют typed actions через явный `onNavigationAction`. Leaf UI получает semantic callbacks и больше не импортирует global owner.
- Публичный navigation-core API (`Route`, `NavState`, snapshot, `NavAction`, `NavReducer`) не расширен demo store-типами.
- README и architectural context описывают lifecycle boundary, atomic frame и честные process-death/animation ограничения.

## TDD и проверки

- RED: focused suite падал только на отсутствующих `AppStore`, `AppStateFrame`, `AppViewModel`.
- GREEN: 15 новых JVM-контрактов — initial/read-only state, atomic Changed/Unchanged, representative sequence, stale callbacks, exact modal IDs, atomic ReplaceHistory, independent owners, concurrent guarded Push и Pop без sleeps.
- Полный JDK 17 `./gradlew testDebugUnitTest --rerun-tasks lintDebug assembleDebug` — PASS.
- 77 tests total; 0 failures/errors/skipped. Lint: 0 errors.
- `git diff --check` и structural ownership grep — PASS.
- Три cross-review: оставшиеся P0–P2 отсутствуют.

## Device evidence

Отдельный read-only Pixel_4 на `emulator-5556` (занятый `5554` не использовался):

1. cold launch → initial Account(1) modal;
2. push → Account Details #1;
3. rotation 0 → 90 вызвал configuration change, процесс сохранился и Details остался видимым;
4. Back после recreation восстановил ту же Account(1) modal-ветку;
5. Compose hierarchy assertions прошли, `AndroidRuntime` crash-log пуст.

Локальные снимки: `/private/tmp/udf-issue-11-recreation-5556.png`, `/private/tmp/udf-issue-11-back-5556.png`. После проверки `emulator-5556` выключен.

## Вне scope

`SavedStateHandle`/process-death restoration, чистая layout projection, renderer/modal redesign и configurable animation policy остаются отдельными roadmap-инкрементами.