### PR TITLE
Добавить чистую проекцию stack-to-layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Navigation as state имеет смысл, только если модель н
 
 ## Основная идея
 
-Текущий прототип хранит линейный `NavState.entries`. Каждый `BackStackEntry` содержит стабильный `EntryId` и semantic `Route`, поэтому два появления одного route остаются независимыми. Content- и modal-routes участвуют в одной истории, а `AnimatedNavigation` проецирует её в один или несколько UI-слотов.
+Текущий navigation core хранит линейный `NavState.entries`. Каждый `BackStackEntry` содержит стабильный `EntryId` и semantic `Route`, поэтому два появления одного route остаются независимыми. Content- и modal-routes участвуют в одной истории, а чистый `NavProjector` преобразует её и явную `NavigationLayoutPolicy` в immutable `NavigationRenderTree`.
 
 Например, один и тот же state рендерится по-разному без изменения navigation history:
 
@@ -31,7 +31,7 @@ Navigation as state имеет смысл, только если модель н
 | --- | --- | --- |
 | `Home -> Accounts -> Account(1)` | `Accounts` занимает root, поверх открыт account bottom sheet | `Home` остаётся в root, `Accounts` показан во вложенном слоте, поверх открыт тот же sheet |
 
-Сейчас `HomeScreen.whereToShowChild` приближённо сопоставляет single-pane с portrait, а multi-pane — с landscape. Это demo-упрощение: в целевой архитектуре layout policy станет явным аргументом чистой функции проекции и не будет выводиться только из orientation.
+Layout policy не читает Android configuration: host выбирает её по доступному пространству и передаёт явно. Compose-renderer пока ещё использует legacy `HomeScreen.whereToShowChild` и orientation; подключение `NavigationRenderTree` вместо этого fold относится к [#13](https://github.com/senneco/udf-sandbox/issues/13).
 
 ## Целевой UDF-цикл
 
@@ -41,12 +41,13 @@ flowchart LR
     Action --> Reducer["Чистый reducer"]
     Reducer --> State["AppState + NavState"]
     State --> Projection["Проекция навигации"]
-    Window["Конфигурация окна"] --> Projection
+    Window["Конфигурация окна"] --> Policy["NavigationLayoutPolicy"]
+    Policy --> Projection
     Projection --> UI
     UI -->|"анимация завершена"| Action
 ```
 
-Navigation core уже содержит валидируемую entry model, сохраняемое primitive-представление истории, typed `NavAction` и чистый `NavReducer`. Activity-scoped `AppViewModel` владеет demo-specific `AppStore`, публикует immutable frames через read-only `StateFlow` и сериализует actions перед reducer. Compose наблюдает flow с учётом lifecycle и передаёт события наверх через явные callbacks. Следующий архитектурный шаг — чистая layout projection.
+Navigation core уже содержит валидируемую entry model, сохраняемое primitive-представление истории, typed `NavAction`, чистый `NavReducer` и чистую stack-to-layout projection. Activity-scoped `AppViewModel` владеет demo-specific `AppStore`, публикует immutable frames через read-only `StateFlow` и сериализует actions перед reducer. Compose наблюдает flow с учётом lifecycle и передаёт события наверх через явные callbacks. Следующий архитектурный шаг — перевести renderer на отдельные previous и target projections.
 
 ## Текущее состояние
 
@@ -61,12 +62,14 @@ Navigation core уже содержит валидируемую entry model, с
 - transient transition intent, который не попадает в `NavState` или snapshot;
 - lifecycle-aware ViewModel и linearizable store как единственную demo-boundary для durable state;
 - lifecycle-aware Compose collection и явные callbacks без глобальных state imports в UI;
+- чистую stack-to-layout projection с явной application-owned layout policy;
+- immutable root-, nested- и modal-слоты с exact-ID ownership modal layers;
 - content и modal destinations в одной логической истории;
 - вложенный рендеринг в landscape;
 - анимированные переходы между content;
 - синхронизацию закрытия bottom sheet обратно в navigation state.
 
-Известные ограничения: store пока является внутренней demo-интеграцией, snapshot не подключён к process-death restoration, а неполная регистрация routes, layout projection и modal bookkeeping остаются внутри renderer. Projection- и lifecycle-restoration tests ещё отсутствуют. Подробный baseline, ограничения и целевая архитектура описаны в [контексте проекта](docs/PROJECT_CONTEXT.md).
+Известные ограничения: store пока является внутренней demo-интеграцией, snapshot не подключён к process-death restoration, а Compose-renderer ещё не потребляет чистую projection. Неполная регистрация routes и legacy modal bookkeeping также остаются внутри renderer; lifecycle-restoration tests ещё отсутствуют. Подробный baseline, ограничения и целевая архитектура описаны в [контексте проекта](docs/PROJECT_CONTEXT.md).
 
 Базовая модель намеренно читается без framework-specific терминов:
 
@@ -81,6 +84,44 @@ val snapshot = state.toSnapshot(DemoRouteCodec)
 ```
 
 Обычный код отдаёт генерацию identity фабрикам, а restoration и deep links могут передать заранее известные IDs через `NavState.fromEntries(...)`. Пользовательские routes реализуют ровно один из открытых интерфейсов `ContentRoute` или `ModalRoute` и подключают собственный `RouteCodec`.
+
+## Чистая layout projection
+
+Policy является маленьким pure Kotlin-правилом. Single-pane всегда заменяет root, а demo expanded-policy оставляет `Home` видимым и помещает его следующего content-child во вложенный слот:
+
+```kotlin
+val singlePane = NavigationLayoutPolicy {
+    ContentPlacementDecision.root()
+}
+
+val expandedPane = NavigationLayoutPolicy { request ->
+    if (request.currentContent.entry.route === Home) {
+        ContentPlacementDecision.childOf(request.currentContent.entry.id)
+    } else {
+        ContentPlacementDecision.root()
+    }
+}
+```
+
+Root создаётся projector-ом автоматически. Policy вызывается только для последующих content entries, поэтому `request.contentPath` всегда непуст, а `request.currentContent` не nullable. Она может выбрать root, существующий slot через `inSlot(...)`, дочерний slot через `childOf(...)` или явно вернуть `reject(code, message)`.
+
+```kotlin
+when (val projection = NavProjector.project(state, expandedPane)) {
+    is NavProjectionResult.Success -> render(projection.tree)
+    is NavProjectionResult.Failure -> report(projection.problem)
+}
+```
+
+Для `Home -> Accounts -> Account(1)` один `NavState` даёт два дерева без изменения history или entry IDs:
+
+| Policy | Root | Nested slots | Modal layers |
+| --- | --- | --- | --- |
+| single-pane | `Accounts` | — | `Account(1)`, owner = exact `Accounts` entry ID |
+| expanded | `Home` | `ChildOf(Home ID) -> Accounts` | `Account(1)`, owner = тот же exact `Accounts` entry ID |
+
+`NavigationRenderTree` и списки внутри `ContentPlacementRequest` делают defensive unmodifiable copies. Invalid child owner, явный policy reject, exception или Java `null` возвращаются соответственно как `NavProjectionProblem.InvalidSlotOwner`, `PolicyRejected` или `PolicyFailed`, а не как частичное дерево. Структурно невалидная history, включая modal-first, отклоняется раньше через `NavState.fromEntries(...)`.
+
+Projection намеренно не знает о Compose и route-to-screen registry: она размещает любые валидные `ContentRoute`/`ModalRoute`. Exhaustive destination binding и фактическое потребление дерева renderer-ом относятся к [#13](https://github.com/senneco/udf-sandbox/issues/13).
 
 ## Переходы состояния
 
@@ -170,7 +211,8 @@ setContent {
 - [`AppState.kt`](app/src/main/java/com/shmakov/udf/AppState.kt), [`AppStore.kt`](app/src/main/java/com/shmakov/udf/AppStore.kt) и [`AppViewModel.kt`](app/src/main/java/com/shmakov/udf/AppViewModel.kt) — immutable application state, linearizable store и Activity-scoped lifecycle owner.
 - [`UdfApp.kt`](app/src/main/java/com/shmakov/udf/UdfApp.kt) — только application initialization и logging; navigation state там не хранится.
 - [`navigation/`](app/src/main/java/com/shmakov/udf/navigation) — routes, back-stack entries, валидируемый navigation state, actions/reducer, snapshot/codec и screen abstractions.
-- [`AnimatedNavigation.kt`](app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt) — проекция стека, вложенный рендеринг, content transitions и modal bookkeeping.
+- [`NavigationProjection.kt`](app/src/main/java/com/shmakov/udf/navigation/NavigationProjection.kt) — pure Kotlin layout policy, immutable render tree и typed projection results.
+- [`AnimatedNavigation.kt`](app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt) — legacy stack fold, вложенный Compose-rendering, content transitions и modal bookkeeping; пока не переведён на `NavigationRenderTree`.
 - [`BottomSheetLayout.kt`](app/src/main/java/com/shmakov/udf/composable/common/BottomSheetLayout.kt) — временное animation state bottom sheet.
 - [`composable/screen/`](app/src/main/java/com/shmakov/udf/composable/screen) — адаптеры экранов и правила размещения дочернего content.
 - [`composable/content/`](app/src/main/java/com/shmakov/udf/composable/content) — минимальный demo UI и текущие navigation triggers.

--- a/app/src/main/java/com/shmakov/udf/navigation/NavigationProjection.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/NavigationProjection.kt
@@ -1,0 +1,324 @@
+package com.shmakov.udf.navigation
+
+import java.util.Collections
+
+/** Identifies one visible content slot independently of the route rendered in it. */
+sealed class ContentSlotId {
+    object Root : ContentSlotId()
+
+    data class ChildOf(
+        val ownerContentEntryId: EntryId,
+    ) : ContentSlotId()
+
+    companion object {
+        @JvmStatic
+        fun root(): ContentSlotId = Root
+
+        @JvmStatic
+        fun childOf(ownerContentEntryId: EntryId): ContentSlotId =
+            ChildOf(ownerContentEntryId)
+    }
+}
+
+/** One content entry and the slot in which it is currently visible. */
+data class ContentSlot(
+    val slotId: ContentSlotId,
+    val entry: BackStackEntry,
+)
+
+/** One visible modal and the exact content occurrence that owns it. */
+data class ModalLayer(
+    val entry: BackStackEntry,
+    val ownerContentEntryId: EntryId,
+)
+
+/** Immutable result of projecting a logical navigation history into visible UI roles. */
+class NavigationRenderTree private constructor(
+    val root: ContentSlot,
+    nestedSlots: List<ContentSlot>,
+    modalLayers: List<ModalLayer>,
+) {
+    val nestedSlots: List<ContentSlot> = projectionImmutableListCopy(nestedSlots)
+    val modalLayers: List<ModalLayer> = projectionImmutableListCopy(modalLayers)
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is NavigationRenderTree &&
+            root == other.root &&
+            nestedSlots == other.nestedSlots &&
+            modalLayers == other.modalLayers
+
+    override fun hashCode(): Int {
+        var result = root.hashCode()
+        result = 31 * result + nestedSlots.hashCode()
+        result = 31 * result + modalLayers.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "NavigationRenderTree(root=$root, nestedSlots=$nestedSlots, modalLayers=$modalLayers)"
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(
+            root: ContentSlot,
+            nestedSlots: List<ContentSlot>,
+            modalLayers: List<ModalLayer>,
+        ): NavigationRenderTree = NavigationRenderTree(root, nestedSlots, modalLayers)
+    }
+}
+
+/** Context supplied when a non-root content entry needs a visible slot. */
+class ContentPlacementRequest private constructor(
+    contentPath: List<ContentSlot>,
+    val currentContent: ContentSlot,
+    val nextContent: BackStackEntry,
+) {
+    val contentPath: List<ContentSlot> = projectionImmutableListCopy(contentPath)
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is ContentPlacementRequest &&
+            contentPath == other.contentPath &&
+            currentContent == other.currentContent &&
+            nextContent == other.nextContent
+
+    override fun hashCode(): Int {
+        var result = contentPath.hashCode()
+        result = 31 * result + currentContent.hashCode()
+        result = 31 * result + nextContent.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "ContentPlacementRequest(contentPath=$contentPath, " +
+            "currentContent=$currentContent, nextContent=$nextContent)"
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(
+            contentPath: List<ContentSlot>,
+            currentContent: ContentSlot,
+            nextContent: BackStackEntry,
+        ): ContentPlacementRequest = ContentPlacementRequest(
+            contentPath = contentPath,
+            currentContent = currentContent,
+            nextContent = nextContent,
+        )
+    }
+}
+
+/** Application-supplied, pure rule for placing content relative to the visible content path. */
+fun interface NavigationLayoutPolicy {
+    fun placeContent(request: ContentPlacementRequest): ContentPlacementDecision
+}
+
+/** Stable value description of why a layout policy cannot place an entry. */
+data class LayoutPolicyError(
+    val code: String,
+    val message: String,
+)
+
+/** A layout policy's decision for one non-root content entry. */
+sealed class ContentPlacementDecision {
+    data class PlaceIn(
+        val slotId: ContentSlotId,
+    ) : ContentPlacementDecision()
+
+    data class Reject(
+        val error: LayoutPolicyError,
+    ) : ContentPlacementDecision()
+
+    companion object {
+        @JvmStatic
+        fun root(): PlaceIn = PlaceIn(ContentSlotId.Root)
+
+        @JvmStatic
+        fun childOf(ownerContentEntryId: EntryId): PlaceIn =
+            PlaceIn(ContentSlotId.ChildOf(ownerContentEntryId))
+
+        @JvmStatic
+        fun inSlot(slotId: ContentSlotId): PlaceIn = PlaceIn(slotId)
+
+        @JvmStatic
+        fun reject(code: String, message: String): Reject =
+            Reject(LayoutPolicyError(code, message))
+    }
+}
+
+/** Contextual reason why a valid navigation state could not be projected. */
+sealed class NavProjectionProblem {
+    data class PolicyRejected(
+        val index: Int,
+        val entry: BackStackEntry,
+        val error: LayoutPolicyError,
+    ) : NavProjectionProblem()
+
+    data class InvalidSlotOwner(
+        val index: Int,
+        val entry: BackStackEntry,
+        val ownerContentEntryId: EntryId,
+    ) : NavProjectionProblem()
+
+    data class PolicyFailed(
+        val index: Int,
+        val entry: BackStackEntry,
+        val error: LayoutPolicyError,
+    ) : NavProjectionProblem()
+}
+
+/** Atomic success or failure from [NavProjector.project]. */
+sealed class NavProjectionResult {
+    data class Success(
+        val tree: NavigationRenderTree,
+    ) : NavProjectionResult()
+
+    data class Failure(
+        val problem: NavProjectionProblem,
+    ) : NavProjectionResult()
+}
+
+/** Pure projection from the validated logical history into a visible render tree. */
+object NavProjector {
+
+    @JvmStatic
+    fun project(
+        navState: NavState,
+        policy: NavigationLayoutPolicy,
+    ): NavProjectionResult {
+        val contentPath = mutableListOf(
+            ContentSlot(
+                slotId = ContentSlotId.Root,
+                entry = navState.root,
+            ),
+        )
+        val modalLayers = mutableListOf<ModalLayer>()
+
+        navState.entries.forEachIndexed { index, entry ->
+            if (index == 0) return@forEachIndexed
+
+            when (entry.route) {
+                is ContentRoute -> {
+                    val request = ContentPlacementRequest.create(
+                        contentPath = contentPath,
+                        currentContent = contentPath.last(),
+                        nextContent = entry,
+                    )
+                    val decision: ContentPlacementDecision? = try {
+                        policy.placeContent(request)
+                    } catch (exception: Exception) {
+                        return NavProjectionResult.Failure(
+                            NavProjectionProblem.PolicyFailed(
+                                index = index,
+                                entry = entry,
+                                error = LayoutPolicyError(
+                                    code = POLICY_EXCEPTION_CODE,
+                                    message = exception.asPolicyFailureMessage(),
+                                ),
+                            ),
+                        )
+                    }
+
+                    when (decision) {
+                        null -> return NavProjectionResult.Failure(
+                            NavProjectionProblem.PolicyFailed(
+                                index = index,
+                                entry = entry,
+                                error = LayoutPolicyError(
+                                    code = NULL_DECISION_CODE,
+                                    message = "Navigation layout policy returned null",
+                                ),
+                            ),
+                        )
+
+                        is ContentPlacementDecision.Reject -> {
+                            return NavProjectionResult.Failure(
+                                NavProjectionProblem.PolicyRejected(
+                                    index = index,
+                                    entry = entry,
+                                    error = decision.error,
+                                ),
+                            )
+                        }
+
+                        is ContentPlacementDecision.PlaceIn -> {
+                            val placementFailure = placeContent(
+                                contentPath = contentPath,
+                                index = index,
+                                entry = entry,
+                                slotId = decision.slotId,
+                            )
+                            if (placementFailure != null) return placementFailure
+
+                            // A content entry later in history hides every preceding modal chain.
+                            modalLayers.clear()
+                        }
+                    }
+                }
+
+                is ModalRoute -> {
+                    modalLayers += ModalLayer(
+                        entry = entry,
+                        ownerContentEntryId = contentPath.last().entry.id,
+                    )
+                }
+            }
+        }
+
+        return NavProjectionResult.Success(
+            NavigationRenderTree.create(
+                root = contentPath.first(),
+                nestedSlots = contentPath.drop(1),
+                modalLayers = modalLayers,
+            ),
+        )
+    }
+
+    private fun placeContent(
+        contentPath: MutableList<ContentSlot>,
+        index: Int,
+        entry: BackStackEntry,
+        slotId: ContentSlotId,
+    ): NavProjectionResult.Failure? = when (slotId) {
+        ContentSlotId.Root -> {
+            contentPath.clear()
+            contentPath += ContentSlot(ContentSlotId.Root, entry)
+            null
+        }
+
+        is ContentSlotId.ChildOf -> {
+            val ownerIndex = contentPath.indexOfFirst {
+                it.entry.id == slotId.ownerContentEntryId
+            }
+            if (ownerIndex == -1) {
+                NavProjectionResult.Failure(
+                    NavProjectionProblem.InvalidSlotOwner(
+                        index = index,
+                        entry = entry,
+                        ownerContentEntryId = slotId.ownerContentEntryId,
+                    ),
+                )
+            } else {
+                while (contentPath.lastIndex > ownerIndex) {
+                    contentPath.removeAt(contentPath.lastIndex)
+                }
+                contentPath += ContentSlot(slotId, entry)
+                null
+            }
+        }
+    }
+}
+
+private const val POLICY_EXCEPTION_CODE = "policy_exception"
+private const val NULL_DECISION_CODE = "null_decision"
+
+private fun Exception.asPolicyFailureMessage(): String = buildString {
+    append(this@asPolicyFailureMessage.javaClass.name)
+    this@asPolicyFailureMessage.message?.let { message ->
+        append(": ")
+        append(message)
+    }
+}
+
+private fun <T> projectionImmutableListCopy(source: Collection<T>): List<T> =
+    Collections.unmodifiableList(ArrayList(source))

--- a/app/src/test/java/com/shmakov/udf/navigation/NavigationProjectionContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/navigation/NavigationProjectionContractTest.kt
@@ -1,0 +1,569 @@
+package com.shmakov.udf.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavigationProjectionContractTest {
+
+    @Test
+    fun `projector always places the validated root without consulting policy`() {
+        val home = entry("home", Home)
+
+        val result = NavProjector.project(
+            state(home),
+            NavigationLayoutPolicy {
+                error("Policy must not be called for the root")
+            },
+        )
+
+        val tree = result.requireSuccess()
+        assertEquals(ContentSlot(ContentSlotId.Root, home), tree.root)
+        assertTrue(tree.nestedSlots.isEmpty())
+        assertTrue(tree.modalLayers.isEmpty())
+    }
+
+    @Test
+    fun `single pane projects every reference content into root`() {
+        val cases = listOf(
+            listOf(entry("home", Home)) to "home",
+            listOf(entry("home", Home), entry("accounts", Accounts)) to "accounts",
+            listOf(
+                entry("home", Home),
+                entry("accounts", Accounts),
+                entry("details", AccountDetails(accountId = 1)),
+            ) to "details",
+        )
+
+        cases.forEach { (history, expectedRootId) ->
+            val tree = NavProjector.project(state(*history.toTypedArray()), singlePane)
+                .requireSuccess()
+
+            assertEquals(EntryId(expectedRootId), tree.root.entry.id)
+            assertEquals(ContentSlotId.Root, tree.root.slotId)
+            assertTrue(tree.nestedSlots.isEmpty())
+        }
+    }
+
+    @Test
+    fun `canonical histories have table-driven expectations for every layout policy`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(accountId = 1))
+        val details = entry("details", AccountDetails(accountId = 1))
+
+        data class ExpectedTree(
+            val root: ContentSlot,
+            val nestedSlots: List<ContentSlot> = emptyList(),
+            val modalLayers: List<ModalLayer> = emptyList(),
+        )
+
+        data class Case(
+            val history: NavState,
+            val single: ExpectedTree,
+            val expanded: ExpectedTree,
+        )
+
+        val rootHome = ContentSlot(ContentSlotId.Root, home)
+        val rootAccounts = ContentSlot(ContentSlotId.Root, accounts)
+        val rootDetails = ContentSlot(ContentSlotId.Root, details)
+        val nestedAccounts = ContentSlot(ContentSlotId.ChildOf(home.id), accounts)
+        val accountLayer = ModalLayer(account, accounts.id)
+        val cases = listOf(
+            Case(
+                history = state(home),
+                single = ExpectedTree(rootHome),
+                expanded = ExpectedTree(rootHome),
+            ),
+            Case(
+                history = state(home, accounts),
+                single = ExpectedTree(rootAccounts),
+                expanded = ExpectedTree(rootHome, nestedSlots = listOf(nestedAccounts)),
+            ),
+            Case(
+                history = state(home, accounts, account),
+                single = ExpectedTree(rootAccounts, modalLayers = listOf(accountLayer)),
+                expanded = ExpectedTree(
+                    root = rootHome,
+                    nestedSlots = listOf(nestedAccounts),
+                    modalLayers = listOf(accountLayer),
+                ),
+            ),
+            Case(
+                history = state(home, accounts, account, details),
+                single = ExpectedTree(rootDetails),
+                expanded = ExpectedTree(rootDetails),
+            ),
+        )
+
+        cases.forEach { case ->
+            listOf(
+                singlePane to case.single,
+                expandedPane to case.expanded,
+            ).forEach { (policy, expected) ->
+                val actual = NavProjector.project(case.history, policy).requireSuccess()
+
+                assertEquals(expected.root, actual.root)
+                assertEquals(expected.nestedSlots, actual.nestedSlots)
+                assertEquals(expected.modalLayers, actual.modalLayers)
+            }
+        }
+    }
+
+    @Test
+    fun `expanded policy keeps Home and places its immediate child in a nested slot`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+
+        val tree = NavProjector.project(state(home, accounts), expandedPane)
+            .requireSuccess()
+
+        assertEquals(ContentSlot(ContentSlotId.Root, home), tree.root)
+        assertEquals(
+            listOf(ContentSlot(ContentSlotId.ChildOf(home.id), accounts)),
+            tree.nestedSlots,
+        )
+    }
+
+    @Test
+    fun `expanded policy resets deeper content to root after Accounts`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(accountId = 1))
+        val details = entry("details", AccountDetails(accountId = 1))
+
+        val tree = NavProjector.project(
+            state(home, accounts, account, details),
+            expandedPane,
+        ).requireSuccess()
+
+        assertEquals(ContentSlot(ContentSlotId.Root, details), tree.root)
+        assertTrue(tree.nestedSlots.isEmpty())
+        assertTrue(tree.modalLayers.isEmpty())
+    }
+
+    @Test
+    fun `root modal is visible and owned by exact root entry`() {
+        val home = entry("home", Home)
+        val account = entry("account", Account(accountId = 1))
+
+        val tree = NavProjector.project(state(home, account), expandedPane)
+            .requireSuccess()
+
+        assertEquals(ContentSlot(ContentSlotId.Root, home), tree.root)
+        assertEquals(listOf(ModalLayer(account, home.id)), tree.modalLayers)
+    }
+
+    @Test
+    fun `account sheet belongs to Accounts in both layouts`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(accountId = 1))
+        val navState = state(home, accounts, account)
+
+        val single = NavProjector.project(navState, singlePane).requireSuccess()
+        val expanded = NavProjector.project(navState, expandedPane).requireSuccess()
+
+        assertEquals(accounts, single.root.entry)
+        assertEquals(home, expanded.root.entry)
+        assertEquals(accounts, expanded.nestedSlots.single().entry)
+        assertEquals(listOf(ModalLayer(account, accounts.id)), single.modalLayers)
+        assertEquals(single.modalLayers, expanded.modalLayers)
+    }
+
+    @Test
+    fun `stacked equal modal routes preserve independent IDs and order`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val first = entry("account-1", Account(accountId = 7))
+        val second = entry("account-2", Account(accountId = 7))
+
+        val tree = NavProjector.project(
+            state(home, accounts, first, second),
+            expandedPane,
+        ).requireSuccess()
+
+        assertNotEquals(first.id, second.id)
+        assertEquals(
+            listOf(
+                ModalLayer(first, accounts.id),
+                ModalLayer(second, accounts.id),
+            ),
+            tree.modalLayers,
+        )
+    }
+
+    @Test
+    fun `a later content hides the previous modal chain`() {
+        val home = entry("home", Home)
+        val account = entry("account", Account(accountId = 1))
+        val accounts = entry("accounts", Accounts)
+
+        val tree = NavProjector.project(state(home, account, accounts), expandedPane)
+            .requireSuccess()
+
+        assertEquals(home, tree.root.entry)
+        assertEquals(accounts, tree.nestedSlots.single().entry)
+        assertTrue(tree.modalLayers.isEmpty())
+    }
+
+    @Test
+    fun `only modals after the latest content are visible`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val oldModal = entry("old-modal", Account(accountId = 1))
+        val details = entry("details", AccountDetails(accountId = 1))
+        val currentModal = entry("current-modal", Account(accountId = 2))
+
+        val tree = NavProjector.project(
+            state(home, accounts, oldModal, details, currentModal),
+            expandedPane,
+        ).requireSuccess()
+
+        assertEquals(details, tree.root.entry)
+        assertEquals(listOf(ModalLayer(currentModal, details.id)), tree.modalLayers)
+    }
+
+    @Test
+    fun `Back reprojects hidden sheet before dismissing it`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(accountId = 1))
+        val details = entry("details", AccountDetails(accountId = 1))
+        val detailsState = state(home, accounts, account, details)
+
+        val detailsTree = NavProjector.project(detailsState, expandedPane).requireSuccess()
+        assertEquals(details, detailsTree.root.entry)
+        assertTrue(detailsTree.modalLayers.isEmpty())
+
+        val sheetState = NavReducer.reduce(detailsState, NavAction.Pop).state
+        val sheetTree = NavProjector.project(sheetState, expandedPane).requireSuccess()
+        assertEquals(home, sheetTree.root.entry)
+        assertEquals(accounts, sheetTree.nestedSlots.single().entry)
+        assertEquals(listOf(ModalLayer(account, accounts.id)), sheetTree.modalLayers)
+
+        val accountsState = NavReducer.reduce(sheetState, NavAction.Pop).state
+        val accountsTree = NavProjector.project(accountsState, expandedPane).requireSuccess()
+        assertEquals(home, accountsTree.root.entry)
+        assertEquals(accounts, accountsTree.nestedSlots.single().entry)
+        assertTrue(accountsTree.modalLayers.isEmpty())
+
+        val homeState = NavReducer.reduce(accountsState, NavAction.Pop).state
+        val homeTree = NavProjector.project(homeState, expandedPane).requireSuccess()
+        assertEquals(home, homeTree.root.entry)
+        assertTrue(homeTree.nestedSlots.isEmpty())
+    }
+
+    @Test
+    fun `recursive pane hosts produce an ordered visible content path`() {
+        val firstHome = entry("home-1", Home)
+        val secondHome = entry("home-2", Home)
+        val accounts = entry("accounts", Accounts)
+
+        val tree = NavProjector.project(
+            state(firstHome, secondHome, accounts),
+            expandedPane,
+        ).requireSuccess()
+
+        assertEquals(firstHome, tree.root.entry)
+        assertEquals(
+            listOf(
+                ContentSlot(ContentSlotId.ChildOf(firstHome.id), secondHome),
+                ContentSlot(ContentSlotId.ChildOf(secondHome.id), accounts),
+            ),
+            tree.nestedSlots,
+        )
+    }
+
+    @Test
+    fun `placing into an earlier visible owner replaces its child and prunes descendants`() {
+        val firstHome = entry("home-1", Home)
+        val secondHome = entry("home-2", Home)
+        val accounts = entry("accounts", Accounts)
+        val details = entry("details", AccountDetails(accountId = 1))
+        val policy = NavigationLayoutPolicy { request ->
+            when (request.nextContent.id) {
+                firstHome.id -> ContentPlacementDecision.root()
+                secondHome.id -> ContentPlacementDecision.childOf(firstHome.id)
+                accounts.id -> ContentPlacementDecision.childOf(secondHome.id)
+                else -> ContentPlacementDecision.childOf(firstHome.id)
+            }
+        }
+
+        val tree = NavProjector.project(
+            state(firstHome, secondHome, accounts, details),
+            policy,
+        ).requireSuccess()
+
+        assertEquals(firstHome, tree.root.entry)
+        assertEquals(
+            listOf(ContentSlot(ContentSlotId.ChildOf(firstHome.id), details)),
+            tree.nestedSlots,
+        )
+    }
+
+    @Test
+    fun `same state and policy produce structurally equal trees`() {
+        val navState = state(
+            entry("home", Home),
+            entry("accounts", Accounts),
+            entry("account", Account(accountId = 1)),
+        )
+
+        val first = NavProjector.project(navState, expandedPane).requireSuccess()
+        val second = NavProjector.project(navState, expandedPane).requireSuccess()
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+        assertEquals(first.toString(), second.toString())
+    }
+
+    @Test
+    fun `switching policy never changes logical state or entry IDs`() {
+        val navState = state(
+            entry("home", Home),
+            entry("accounts", Accounts),
+            entry("account", Account(accountId = 1)),
+        )
+        val entriesBefore = navState.entries.toList()
+
+        val single = NavProjector.project(navState, singlePane).requireSuccess()
+        val expanded = NavProjector.project(navState, expandedPane).requireSuccess()
+
+        assertEquals(entriesBefore, navState.entries)
+        assertEquals(entriesBefore.map { it.id }, navState.entries.map { it.id })
+        assertNotEquals(single, expanded)
+    }
+
+    @Test
+    fun `equal content routes with different IDs stay distinct in a nested path`() {
+        val first = entry("home-1", Home)
+        val second = entry("home-2", Home)
+
+        val tree = NavProjector.project(state(first, second), expandedPane)
+            .requireSuccess()
+
+        assertEquals(first, tree.root.entry)
+        assertEquals(second, tree.nestedSlots.single().entry)
+        assertNotEquals(tree.root.entry.id, tree.nestedSlots.single().entry.id)
+    }
+
+    @Test
+    fun `policy sees an immutable defensive content path`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        var pathSeen: List<ContentSlot>? = null
+        val policy = NavigationLayoutPolicy { request ->
+            pathSeen = request.contentPath
+            assertThrows(UnsupportedOperationException::class.java) {
+                @Suppress("UNCHECKED_CAST")
+                (request.contentPath as MutableList<ContentSlot>).clear()
+            }
+            ContentPlacementDecision.childOf(request.currentContent.entry.id)
+        }
+
+        val tree = NavProjector.project(state(home, accounts), policy).requireSuccess()
+
+        assertEquals(listOf(tree.root), pathSeen)
+        assertEquals(accounts, tree.nestedSlots.single().entry)
+    }
+
+    @Test
+    fun `tree constructor and exposed lists make defensive unmodifiable copies`() {
+        val root = ContentSlot(ContentSlotId.Root, entry("home", Home))
+        val child = ContentSlot(
+            ContentSlotId.ChildOf(root.entry.id),
+            entry("accounts", Accounts),
+        )
+        val modal = ModalLayer(entry("account", Account(accountId = 1)), child.entry.id)
+        val nestedSource = mutableListOf(child)
+        val modalSource = mutableListOf(modal)
+
+        val tree = NavigationRenderTree.create(root, nestedSource, modalSource)
+        nestedSource.clear()
+        modalSource.clear()
+
+        assertEquals(listOf(child), tree.nestedSlots)
+        assertEquals(listOf(modal), tree.modalLayers)
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (tree.nestedSlots as MutableList<ContentSlot>).clear()
+        }
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (tree.modalLayers as MutableList<ModalLayer>).clear()
+        }
+    }
+
+    @Test
+    fun `explicit policy rejection is a contextual atomic failure`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val error = LayoutPolicyError("unsupported_destination", "Accounts is disabled")
+        val policy = NavigationLayoutPolicy { request ->
+            if (request.nextContent.id == accounts.id) {
+                ContentPlacementDecision.Reject(error)
+            } else {
+                ContentPlacementDecision.root()
+            }
+        }
+
+        val failure = NavProjector.project(state(home, accounts), policy).requireFailure()
+
+        assertEquals(
+            NavProjectionProblem.PolicyRejected(
+                index = 1,
+                entry = accounts,
+                error = error,
+            ),
+            failure.problem,
+        )
+    }
+
+    @Test
+    fun `a child of an invisible owner is an atomic failure`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val missingOwner = EntryId("missing")
+        val policy = NavigationLayoutPolicy {
+            ContentPlacementDecision.childOf(missingOwner)
+        }
+
+        val failure = NavProjector.project(state(home, accounts), policy).requireFailure()
+
+        assertEquals(
+            NavProjectionProblem.InvalidSlotOwner(
+                index = 1,
+                entry = accounts,
+                ownerContentEntryId = missingOwner,
+            ),
+            failure.problem,
+        )
+    }
+
+    @Test
+    fun `policy exception becomes a value error without leaking Throwable`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+
+        val failure = NavProjector.project(
+            state(home, accounts),
+            NavigationLayoutPolicy { throw IllegalStateException("boom") },
+        ).requireFailure()
+
+        val problem = failure.problem as NavProjectionProblem.PolicyFailed
+        assertEquals(1, problem.index)
+        assertEquals(accounts, problem.entry)
+        assertEquals("policy_exception", problem.error.code)
+        assertTrue(problem.error.message.contains("IllegalStateException"))
+        assertTrue(problem.error.message.contains("boom"))
+    }
+
+    @Test
+    fun `a failure after modal and nested work exposes no partial tree`() {
+        val home = entry("home", Home)
+        val accounts = entry("accounts", Accounts)
+        val account = entry("account", Account(accountId = 1))
+        val details = entry("details", AccountDetails(accountId = 1))
+        val policy = NavigationLayoutPolicy { request ->
+            when (request.nextContent.id) {
+                home.id -> ContentPlacementDecision.root()
+                accounts.id -> ContentPlacementDecision.childOf(home.id)
+                else -> ContentPlacementDecision.reject("unsupported_destination", "details")
+            }
+        }
+
+        val result = NavProjector.project(state(home, accounts, account, details), policy)
+
+        assertTrue(result is NavProjectionResult.Failure)
+        val problem = (result as NavProjectionResult.Failure).problem
+        assertEquals(
+            NavProjectionProblem.PolicyRejected(
+                index = 3,
+                entry = details,
+                error = LayoutPolicyError("unsupported_destination", "details"),
+            ),
+            problem,
+        )
+    }
+
+    @Test
+    fun `policy is called only for content entries`() {
+        val home = entry("home", Home)
+        val firstModal = entry("modal-1", Account(accountId = 1))
+        val accounts = entry("accounts", Accounts)
+        val secondModal = entry("modal-2", Account(accountId = 2))
+        val calls = mutableListOf<EntryId>()
+
+        val result = NavProjector.project(
+            state(home, firstModal, accounts, secondModal),
+            NavigationLayoutPolicy { request ->
+                calls += request.nextContent.id
+                ContentPlacementDecision.root()
+            },
+        )
+
+        result.requireSuccess()
+        assertEquals(listOf(accounts.id), calls)
+    }
+
+    @Test
+    fun `modal-first and other malformed histories are rejected before projection`() {
+        val empty = NavState.fromEntries(emptyList())
+        val modalFirst = NavState.fromEntries(
+            listOf(entry("account", Account(accountId = 1))),
+        )
+        val duplicate = entry("same", Home).let { root ->
+            NavState.fromEntries(listOf(root, entry("same", Accounts)))
+        }
+
+        assertEquals(
+            listOf(NavStateProblem.EmptyStack),
+            (empty as NavStateCreationResult.Invalid).problems,
+        )
+        assertEquals(
+            listOf(NavStateProblem.NonContentRoot(EntryId("account"))),
+            (modalFirst as NavStateCreationResult.Invalid).problems,
+        )
+        assertTrue(
+            (duplicate as NavStateCreationResult.Invalid).problems
+                .contains(NavStateProblem.DuplicateEntryId(EntryId("same"))),
+        )
+    }
+
+    private fun NavProjectionResult.requireSuccess(): NavigationRenderTree {
+        assertTrue("Expected Success, got $this", this is NavProjectionResult.Success)
+        return (this as NavProjectionResult.Success).tree
+    }
+
+    private fun NavProjectionResult.requireFailure(): NavProjectionResult.Failure {
+        assertTrue("Expected Failure, got $this", this is NavProjectionResult.Failure)
+        return this as NavProjectionResult.Failure
+    }
+
+    private fun state(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> error("Invalid fixture: ${result.problems}")
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        BackStackEntry(EntryId(id), route)
+
+    private companion object {
+        val singlePane = NavigationLayoutPolicy {
+            ContentPlacementDecision.root()
+        }
+
+        val expandedPane = NavigationLayoutPolicy { request ->
+            val current = request.currentContent
+            if (current.entry.route is Home) {
+                ContentPlacementDecision.childOf(current.entry.id)
+            } else {
+                ContentPlacementDecision.root()
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/shmakov/udf/navigation/NavigationProjectionJavaApiTest.java
+++ b/app/src/test/java/com/shmakov/udf/navigation/NavigationProjectionJavaApiTest.java
@@ -1,0 +1,69 @@
+package com.shmakov.udf.navigation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import org.junit.Test;
+
+public final class NavigationProjectionJavaApiTest {
+
+    @Test
+    public void projectorAndPlacementFactoriesNeedNoKotlinCompanionSyntax() {
+        BackStackEntry home = new BackStackEntry(new EntryId("home"), Home.INSTANCE);
+        BackStackEntry accounts = new BackStackEntry(new EntryId("accounts"), Accounts.INSTANCE);
+        NavStateCreationResult created = NavState.fromEntries(java.util.Arrays.asList(home, accounts));
+        NavState state = ((NavStateCreationResult.Valid) created).getState();
+
+        NavigationLayoutPolicy policy = request -> {
+            assertEquals(Collections.singletonList(
+                    new ContentSlot(ContentSlotId.root(), home)
+            ), request.getContentPath());
+            assertEquals(home, request.getCurrentContent().getEntry());
+            assertEquals(accounts, request.getNextContent());
+            return ContentPlacementDecision.root();
+        };
+
+        NavProjectionResult result = NavProjector.project(state, policy);
+
+        assertTrue(result instanceof NavProjectionResult.Success);
+        NavigationRenderTree tree = ((NavProjectionResult.Success) result).getTree();
+        assertEquals(ContentSlotId.root(), tree.getRoot().getSlotId());
+        assertEquals(accounts, tree.getRoot().getEntry());
+        assertTrue(tree.getNestedSlots().isEmpty());
+        assertTrue(tree.getModalLayers().isEmpty());
+
+        assertEquals(
+                new ContentPlacementDecision.PlaceIn(ContentSlotId.childOf(home.getId())),
+                ContentPlacementDecision.childOf(home.getId())
+        );
+        assertEquals(
+                new ContentPlacementDecision.PlaceIn(ContentSlotId.root()),
+                ContentPlacementDecision.inSlot(ContentSlotId.root())
+        );
+        assertEquals(
+                new ContentPlacementDecision.Reject(
+                        new LayoutPolicyError("unsupported", "not available")
+                ),
+                ContentPlacementDecision.reject("unsupported", "not available")
+        );
+    }
+
+    @Test
+    public void JavaNullPolicyResultBecomesTypedFailure() {
+        BackStackEntry home = new BackStackEntry(new EntryId("home"), Home.INSTANCE);
+        BackStackEntry accounts = new BackStackEntry(new EntryId("accounts"), Accounts.INSTANCE);
+        NavStateCreationResult created = NavState.fromEntries(java.util.Arrays.asList(home, accounts));
+        NavState state = ((NavStateCreationResult.Valid) created).getState();
+
+        NavProjectionResult result = NavProjector.project(state, request -> null);
+
+        assertTrue(result instanceof NavProjectionResult.Failure);
+        NavProjectionProblem problem = ((NavProjectionResult.Failure) result).getProblem();
+        assertTrue(problem instanceof NavProjectionProblem.PolicyFailed);
+        NavProjectionProblem.PolicyFailed failed = (NavProjectionProblem.PolicyFailed) problem;
+        assertEquals(1, failed.getIndex());
+        assertEquals(accounts, failed.getEntry());
+        assertEquals("null_decision", failed.getError().getCode());
+    }
+}

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -38,7 +38,9 @@ Navigation input представлен закрытым набором typed `N
 
 `NavTransitionIntent` описывает только что совершившийся Push, Pop, branch replacement, modal dismiss или full-history replacement. Он возвращается отдельно от durable `NavState` и не попадает в snapshot. Demo-specific `AppStore` атомарно связывает immutable `AppState` и последний intent в process-local `AppStateFrame`; `AppViewModel` удерживает store в lifecycle конкретной Activity. Intent остаётся metadata текущего frame до следующего `Changed`, а renderer использует его для выбора legacy motion. Одноразовое consumption и настраиваемая animation policy появятся отдельными инкрементами.
 
-`AnimatedNavigation(navState, navTransition)` сворачивает entries и выбирает content для конкретного внутреннего render slot. `Screen.whereToShowChild` может вернуть другой слот, поэтому одна логическая история имеет разные физические layout-проекции.
+`NavProjector.project(navState, policy)` чисто преобразует валидную history в `NavigationRenderTree`: один root `ContentSlot`, упорядоченные nested slots и modal layers с exact `ownerContentEntryId`. Root размещается автоматически; application-owned `NavigationLayoutPolicy` вызывается только для последующих content entries и получает непустой immutable content path.
+
+Projection уже отделена от Android и Compose, но `AnimatedNavigation(navState, navTransition)` пока продолжает сворачивать entries самостоятельно через legacy `Screen.whereToShowChild`. Подключение renderer-а к отдельным previous и target trees относится к [#13](https://github.com/senneco/udf-sandbox/issues/13).
 
 Для `Home -> Accounts -> Account(1)`:
 
@@ -99,7 +101,7 @@ Route отвечает на вопрос «куда», entry — «какое и
 - branch replacement полезен, когда родитель остаётся видимым и выбирает другого ребёнка;
 - удалённый modal entry иногда нужно временно удерживать в presentation state до завершения exit-анимации.
 
-Reducer contract покрывает эталонные state transitions и подключён к lifecycle-aware owner. Store contracts доказывают атомарные frames, stale callbacks, независимых owners и сериализацию concurrent actions, но чистая projection, renderer races, process restoration и сложные анимации ещё не доказаны end-to-end.
+Reducer contract покрывает эталонные state transitions и подключён к lifecycle-aware owner. Store contracts доказывают атомарные frames, stale callbacks, независимых owners и сериализацию concurrent actions. Projection contracts отдельно доказывают single-/expanded размещение, modal ownership, content после modal, Back reprojection, immutable collections, typed policy failures и Java API; renderer races, process restoration и сложные анимации ещё не доказаны end-to-end.
 
 ## Текущий data flow
 
@@ -123,7 +125,7 @@ UI / renderer callback -> AppViewModel.dispatch(NavAction)
                        -> Compose rendering
 ```
 
-`MainActivity` получает read-only `StateFlow<AppStateFrame>` через `collectAsStateWithLifecycle`. Screen adapters создают typed actions, leaf composables получают semantic callbacks, а renderer только сообщает modal completion. `UdfApp` больше не хранит navigation state. Чистая projection, process restoration и настраиваемая reducer-to-renderer animation policy пока отсутствуют.
+`MainActivity` получает read-only `StateFlow<AppStateFrame>` через `collectAsStateWithLifecycle`. Screen adapters создают typed actions, leaf composables получают semantic callbacks, а renderer только сообщает modal completion. `UdfApp` больше не хранит navigation state. Чистая projection существует как отдельная core-boundary; её интеграция с renderer-ом, process restoration и настраиваемая reducer-to-renderer animation policy пока отсутствуют.
 
 ## Известные риски и незавершённая работа
 
@@ -144,7 +146,9 @@ UI / renderer callback -> AppViewModel.dispatch(NavAction)
 
 ### Проекция и рендеринг
 
-- projection logic находится внутри composable и читает orientation из окружения.
+- pure Kotlin `NavProjector` принимает явную `NavigationLayoutPolicy` и не изменяет `NavState`;
+- один и тот же state можно перепроецировать другой policy с сохранением history и entry IDs;
+- Compose-renderer пока не использует `NavigationRenderTree`: legacy fold и чтение orientation остаются внутри composable до следующего renderer-инкремента;
 - registry destinations реализован ручными `when` и завершается небезопасным `!!`.
 - объявленные `Transaction` и `Card` не имеют зарегистрированного content screen.
 - outgoing `AnimatedContent` может получить nested tail, рассчитанный для incoming state, и визуально «прыгнуть» во время exit.
@@ -165,7 +169,7 @@ UI / renderer callback -> AppViewModel.dispatch(NavAction)
 
 ### Надёжность и поддержка
 
-- model, identity, snapshot, reducer и store serialization покрыты JVM contract tests, но projection- и lifecycle-restoration tests ещё отсутствуют;
+- model, identity, snapshot, reducer, store serialization и projection покрыты JVM contract tests, но lifecycle-restoration tests ещё отсутствуют;
 - Android/Compose toolchain отражает исходный прототип и должен обновляться только после появления safety net;
 - demo UI смешивает Material 2 и Material 3.
 
@@ -180,8 +184,8 @@ UI/System event
     -> NavReducer.reduce(previous NavState, NavAction)
     -> NavReduction
     -> AppStateFrame(AppState, transient NavTransitionIntent?)
-    -> project(NavState, WindowConfiguration)
-    -> NavigationTree(root, nested slots, modals)
+    -> NavProjector.project(NavState, NavigationLayoutPolicy)
+    -> NavigationRenderTree(root, nested slots, modal layers)
     -> Compose rendering
 ```
 
@@ -206,13 +210,16 @@ object NavReducer {
     ): NavReduction
 }
 
-fun project(
-    navState: NavState,
-    window: WindowConfiguration,
-): NavigationTree
+object NavProjector {
+    @JvmStatic
+    fun project(
+        navState: NavState,
+        policy: NavigationLayoutPolicy,
+    ): NavProjectionResult
+}
 ```
 
-Route, entry identity, validated `NavState`, primitive snapshot, pure reducer и lifecycle-aware state owner уже реализуют deterministic state boundary этой схемы. `AppStateFrame` согласованно передаёт state и transition intent renderer-у; чистая projection, process restoration и настраиваемая animation policy ещё не реализованы.
+Route, entry identity, validated `NavState`, primitive snapshot, pure reducer, lifecycle-aware state owner и чистая projection уже реализуют deterministic state boundary этой схемы. `AppStateFrame` согласованно передаёт state и transition intent renderer-у; renderer integration, process restoration и настраиваемая animation policy ещё не реализованы.
 
 ## Обязательные инварианты
 
@@ -224,7 +231,7 @@ Route, entry identity, validated `NavState`, primitive snapshot, pure reducer и
 4. `Pop` не удаляет защищённый root.
 5. Durable modal dismiss адресует конкретный entry ID и является idempotent; animation completion меняет только presentation state.
 6. Каждый route имеет exhaustive renderer или явный unsupported-state result.
-7. Для одинаковых state и window input projection одинакова.
+7. Для одинаковых state и layout policy projection одинакова.
 8. Projection не изменяет application state.
 9. Activity recreation и process restoration воспроизводят ту же логическую историю.
 10. Local UI state сохраняется или осознанно удаляется по entry identity.
@@ -235,7 +242,8 @@ Route, entry identity, validated `NavState`, primitive snapshot, pure reducer и
 - Предпочитать чистый Kotlin для state, reducer и projection.
 - Не смешивать миграцию поведения с массовым обновлением зависимостей или форматированием.
 - Сначала зафиксировать ожидаемое поведение, затем заменять renderer.
-- Передавать в projection явную layout policy; конкретный Android API выбирается отдельно, а orientation остаётся только временным demo-упрощением.
+- Передавать в projection явную application-owned layout policy; конкретный Android API выбирается отдельно, а orientation остаётся только временным demo-упрощением legacy renderer-а.
+- Projection остаётся route-agnostic: exhaustive route-to-screen registry принадлежит renderer boundary, а не layout policy.
 - Не сохранять animation progress в navigation state.
 - Не сохранять `NavTransitionIntent` в navigation state или snapshot; `Unchanged` не создаёт transition.
 - Logout и deep link заменяют полную валидную history атомарным `ReplaceHistory`.
@@ -290,6 +298,7 @@ Route, entry identity, validated `NavState`, primitive snapshot, pure reducer и
 - `app/src/main/java/com/shmakov/udf/navigation/NavState.kt`
 - `app/src/main/java/com/shmakov/udf/navigation/NavStateSnapshot.kt`
 - `app/src/main/java/com/shmakov/udf/navigation/NavigationReducer.kt`
+- `app/src/main/java/com/shmakov/udf/navigation/NavigationProjection.kt`
 - `app/src/main/java/com/shmakov/udf/navigation/Screen.kt`
 - `app/src/main/java/com/shmakov/udf/composable/common/AnimatedNavigation.kt`
 - `app/src/main/java/com/shmakov/udf/composable/common/BottomSheetLayout.kt`


### PR DESCRIPTION
Closes #12

## Что изменено

- Добавлен pure Kotlin `NavProjector.project(navState, policy)`: валидный логический stack преобразуется в immutable `NavigationRenderTree`.
- Root размещается projector-ом автоматически; application-owned `NavigationLayoutPolicy` решает только размещение последующих content entries.
- Render tree явно содержит root, ordered nested slots и modal layers. Каждый modal связан с точным `ownerContentEntryId`, а одинаковые routes сохраняют независимую entry identity.
- `root()` заменяет весь visible content path; `childOf(ownerId)` создаёт/заменяет child видимого owner и обрезает descendants.
- Policy reject, отсутствующий slot owner, exception и Java `null` возвращают typed atomic `Failure`, без partial tree.
- Все list boundaries defensive/runtime-unmodifiable; tree имеет structural equality.
- README и PROJECT_CONTEXT документируют single/expanded policies, результат, ошибки и честную границу: legacy Compose renderer перейдёт на projection в #13.

## TDD и проверки

- RED: test compilation падала только на отсутствующем projection API; production compilation оставалась зелёной.
- GREEN: 24 Kotlin contract tests + 2 Java API tests.
- Общая table-driven matrix покрывает `Home`, `Home → Accounts`, account sheet и `AccountDetails` для single/expanded policies.
- Отдельно покрыты stacked equal modals/different IDs, root modal, content-after-modal, последовательный Back, recursive nesting, pruning, determinism, immutable collections и policy failure paths.
- Полный JDK 17 gate: `./gradlew testDebugUnitTest lintDebug assembleDebug` — PASS.
- 103 JVM tests total; 0 failures/errors/skipped. Lint: 0 errors.
- Pure-source grep и `git diff --check` — PASS.
- Два независимых API/runtime review и отдельный final gate: P0–P2 отсутствуют.

## UI evidence

Observable Compose UI в #12 не меняется: renderer намеренно остаётся на legacy fold до #13. Поэтому device/emulator run для этого pure-core инкремента не выполнялся.

## Вне scope

Previous/outgoing projections, renderer registry/integration, animation policy и retained modal presentation остаются в #13–#15.