### PR TITLE
Introduce immutable tab navigation graph model

### DIFF
--- a/app/src/main/java/com/shmakov/udf/navigation/TabNavigationState.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/TabNavigationState.kt
@@ -1,0 +1,181 @@
+package com.shmakov.udf.navigation
+
+import java.util.Collections
+
+/** Stable, application-defined identity of one tab in a navigation graph. */
+data class TabId(val value: String)
+
+/** One tab and the independent leaf navigation history currently owned by it. */
+data class TabState(
+    val id: TabId,
+    val history: NavState,
+)
+
+/** A structural invariant violation found while creating a [TabNavigationState]. */
+sealed class TabNavigationStateProblem {
+    object EmptyTabs : TabNavigationStateProblem()
+
+    data class BlankTabId(val index: Int) : TabNavigationStateProblem()
+
+    data class DuplicateTabId(
+        val tabId: TabId,
+        val firstIndex: Int,
+        val duplicateIndex: Int,
+    ) : TabNavigationStateProblem()
+
+    data class SelectedTabNotFound(val selectedTabId: TabId) : TabNavigationStateProblem()
+
+    /**
+     * One route-occurrence identity cannot belong to two tabs in the same graph.
+     *
+     * Keeping [EntryId] graph-wide makes entry ownership, renderer keys, and saveable-state keys
+     * describe the same occurrence without adding a second hidden identity scheme.
+     */
+    data class DuplicateEntryId(
+        val entryId: EntryId,
+        val firstTabId: TabId,
+        val duplicateTabId: TabId,
+        val firstTabIndex: Int,
+        val duplicateTabIndex: Int,
+    ) : TabNavigationStateProblem()
+}
+
+/** Result of validating caller-controlled tabs with [TabNavigationState.fromTabs]. */
+sealed class TabNavigationStateCreationResult {
+    data class Valid(val state: TabNavigationState) : TabNavigationStateCreationResult()
+
+    data class Invalid(
+        val problems: List<TabNavigationStateProblem>,
+    ) : TabNavigationStateCreationResult()
+}
+
+/**
+ * Immutable state of one tab container and all independent navigation histories it owns.
+ *
+ * [tabs] is ordered deliberately: application UI can render a deterministic tab bar without a
+ * separate ordering convention. Labels and icons remain application configuration, not durable
+ * navigation state.
+ */
+class TabNavigationState private constructor(
+    val selectedTabId: TabId,
+    tabs: List<TabState>,
+) {
+    /** A defensive, runtime-unmodifiable view in deterministic tab-bar order. */
+    val tabs: List<TabState> = immutableTabListCopy(tabs)
+
+    /** The selected tab. Its presence is guaranteed by [create]. */
+    val selectedTab: TabState
+        get() = checkNotNull(this[selectedTabId]) {
+            "TabNavigationState invariant broken: selected tab $selectedTabId is missing"
+        }
+
+    /** Returns the tab with [tabId], or `null` when it does not belong to this graph. */
+    operator fun get(tabId: TabId): TabState? = tabs.firstOrNull { it.id == tabId }
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is TabNavigationState &&
+            selectedTabId == other.selectedTabId &&
+            tabs == other.tabs
+
+    override fun hashCode(): Int = 31 * selectedTabId.hashCode() + tabs.hashCode()
+
+    override fun toString(): String =
+        "TabNavigationState(selectedTabId=$selectedTabId, tabs=$tabs)"
+
+    companion object {
+        /** Creates a known-valid application graph, throwing on programmer configuration errors. */
+        @JvmStatic
+        fun create(
+            selectedTabId: TabId,
+            tabs: List<TabState>,
+        ): TabNavigationState = when (val result = fromTabs(selectedTabId, tabs)) {
+            is TabNavigationStateCreationResult.Valid -> result.state
+            is TabNavigationStateCreationResult.Invalid -> throw IllegalArgumentException(
+                "Invalid tab navigation state: ${result.problems.joinToString()}",
+            )
+        }
+
+        /** Validates caller-controlled tabs supplied by restoration, decoding, or deep links. */
+        @JvmStatic
+        fun fromTabs(
+            selectedTabId: TabId,
+            tabs: List<TabState>,
+        ): TabNavigationStateCreationResult {
+            val tabsCopy = ArrayList(tabs)
+            val problems = validateTabNavigationState(selectedTabId, tabsCopy)
+            return if (problems.isEmpty()) {
+                TabNavigationStateCreationResult.Valid(
+                    TabNavigationState(selectedTabId, tabsCopy),
+                )
+            } else {
+                TabNavigationStateCreationResult.Invalid(
+                    immutableProblemListCopy(problems),
+                )
+            }
+        }
+    }
+}
+
+private fun validateTabNavigationState(
+    selectedTabId: TabId,
+    tabs: List<TabState>,
+): List<TabNavigationStateProblem> {
+    if (tabs.isEmpty()) return listOf(TabNavigationStateProblem.EmptyTabs)
+
+    val problems = mutableListOf<TabNavigationStateProblem>()
+
+    tabs.forEachIndexed { index, tab ->
+        if (tab.id.value.isBlank()) {
+            problems += TabNavigationStateProblem.BlankTabId(index)
+        }
+    }
+
+    val firstIndexByTabId = mutableMapOf<TabId, Int>()
+    val reportedDuplicateTabIds = mutableSetOf<TabId>()
+    tabs.forEachIndexed { index, tab ->
+        val firstIndex = firstIndexByTabId.putIfAbsent(tab.id, index)
+        if (firstIndex != null && reportedDuplicateTabIds.add(tab.id)) {
+            problems += TabNavigationStateProblem.DuplicateTabId(
+                tabId = tab.id,
+                firstIndex = firstIndex,
+                duplicateIndex = index,
+            )
+        }
+    }
+
+    if (tabs.none { it.id == selectedTabId }) {
+        problems += TabNavigationStateProblem.SelectedTabNotFound(selectedTabId)
+    }
+
+    val ownerByEntryId = mutableMapOf<EntryId, EntryOwner>()
+    tabs.forEachIndexed { tabIndex, tab ->
+        tab.history.entries.forEach { entry ->
+            val owner = EntryOwner(tab.id, tabIndex)
+            val firstOwner = ownerByEntryId.putIfAbsent(entry.id, owner)
+            if (firstOwner != null && firstOwner.tabIndex != tabIndex) {
+                problems += TabNavigationStateProblem.DuplicateEntryId(
+                    entryId = entry.id,
+                    firstTabId = firstOwner.tabId,
+                    duplicateTabId = tab.id,
+                    firstTabIndex = firstOwner.tabIndex,
+                    duplicateTabIndex = tabIndex,
+                )
+            }
+        }
+    }
+
+    return problems
+}
+
+private data class EntryOwner(
+    val tabId: TabId,
+    val tabIndex: Int,
+)
+
+private fun immutableTabListCopy(source: Collection<TabState>): List<TabState> =
+    Collections.unmodifiableList(ArrayList(source))
+
+private fun immutableProblemListCopy(
+    source: Collection<TabNavigationStateProblem>,
+): List<TabNavigationStateProblem> = Collections.unmodifiableList(ArrayList(source))

--- a/app/src/test/java/com/shmakov/udf/navigation/TabNavigationJavaApiTest.java
+++ b/app/src/test/java/com/shmakov/udf/navigation/TabNavigationJavaApiTest.java
@@ -1,0 +1,46 @@
+package com.shmakov.udf.navigation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public final class TabNavigationJavaApiTest {
+
+    @Test
+    public void graphFactoryAndLookupAreUsableWithoutKotlinCompanionSyntax() {
+        TabId accountsId = new TabId("accounts");
+        NavState accountsNavigation = validNavigation(
+                new BackStackEntry(new EntryId("accounts-root"), Accounts.INSTANCE)
+        );
+        TabState accounts = new TabState(accountsId, accountsNavigation);
+        TabState cards = new TabState(
+                new TabId("cards"),
+                validNavigation(new BackStackEntry(new EntryId("cards-root"), Cards.INSTANCE))
+        );
+
+        TabNavigationState state = TabNavigationState.create(
+                accountsId,
+                Arrays.asList(accounts, cards)
+        );
+        TabNavigationStateCreationResult validated = TabNavigationState.fromTabs(
+                accountsId,
+                Arrays.asList(accounts, cards)
+        );
+
+        assertTrue(validated instanceof TabNavigationStateCreationResult.Valid);
+        assertEquals(accountsId, state.getSelectedTabId());
+        assertSame(accounts, state.getSelectedTab());
+        assertSame(accountsNavigation, state.get(accountsId).getHistory());
+        assertEquals(Arrays.asList(accounts, cards), state.getTabs());
+    }
+
+    private static NavState validNavigation(BackStackEntry root) {
+        NavStateCreationResult created = NavState.fromEntries(Collections.singletonList(root));
+        assertTrue(created instanceof NavStateCreationResult.Valid);
+        return ((NavStateCreationResult.Valid) created).getState();
+    }
+}

--- a/app/src/test/java/com/shmakov/udf/navigation/TabNavigationStateContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/navigation/TabNavigationStateContractTest.kt
@@ -1,0 +1,260 @@
+package com.shmakov.udf.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TabNavigationStateContractTest {
+
+    @Test
+    fun `valid graph exposes selected tab and preserves every independent exact history`() {
+        val accountsNavigation = navigation(
+            BackStackEntry(EntryId("accounts"), Accounts),
+            BackStackEntry(EntryId("account-1"), Account(accountId = 1)),
+            BackStackEntry(EntryId("account-details-1"), AccountDetails(accountId = 1)),
+        )
+        val cardsNavigation = navigation(
+            BackStackEntry(EntryId("cards"), Cards),
+            BackStackEntry(EntryId("card-7"), Card(cardId = 7)),
+        )
+        val accounts = TabState(TabId("accounts"), accountsNavigation)
+        val cards = TabState(TabId("cards"), cardsNavigation)
+
+        val graph = TabNavigationState.create(
+            selectedTabId = accounts.id,
+            tabs = listOf(accounts, cards),
+        )
+
+        assertEquals(accounts.id, graph.selectedTabId)
+        assertSame(accounts, graph.selectedTab)
+        assertEquals(listOf(accounts, cards), graph.tabs)
+        assertSame(accountsNavigation, graph[accounts.id]?.history)
+        assertSame(cardsNavigation, graph[cards.id]?.history)
+        assertEquals(null, graph[TabId("profile")])
+    }
+
+    @Test
+    fun `graphs with equal ordered tabs are structurally equal`() {
+        val firstTabs = listOf(
+            TabState(TabId("accounts"), navigation(entry("accounts", Accounts))),
+            TabState(TabId("cards"), navigation(entry("cards", Cards))),
+        )
+        val equalTabs = listOf(
+            TabState(TabId("accounts"), navigation(entry("accounts", Accounts))),
+            TabState(TabId("cards"), navigation(entry("cards", Cards))),
+        )
+
+        val first = TabNavigationState.create(firstTabs.first().id, firstTabs)
+        val second = TabNavigationState.create(equalTabs.first().id, equalTabs)
+        val otherSelection = TabNavigationState.create(equalTabs.last().id, equalTabs)
+        val otherOrder = TabNavigationState.create(
+            equalTabs.first().id,
+            equalTabs.reversed(),
+        )
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+        assertNotEquals(first, otherSelection)
+        assertNotEquals(first, otherOrder)
+        assertEquals(
+            "TabNavigationState(selectedTabId=TabId(value=accounts), tabs=$firstTabs)",
+            first.toString(),
+        )
+    }
+
+    @Test
+    fun `empty tab graph is rejected explicitly`() {
+        val problems = invalidProblems(
+            TabNavigationState.fromTabs(
+                selectedTabId = TabId("accounts"),
+                tabs = emptyList(),
+            ),
+        )
+
+        assertEquals(listOf(TabNavigationStateProblem.EmptyTabs), problems)
+    }
+
+    @Test
+    fun `blank tab ID reports its position`() {
+        val tabs = listOf(
+            TabState(TabId("accounts"), navigation(entry("accounts", Accounts))),
+            TabState(TabId("  "), navigation(entry("cards", Cards))),
+        )
+
+        val problems = invalidProblems(TabNavigationState.fromTabs(tabs.first().id, tabs))
+
+        assertEquals(
+            listOf(TabNavigationStateProblem.BlankTabId(index = 1)),
+            problems,
+        )
+    }
+
+    @Test
+    fun `duplicate tab ID is rejected explicitly`() {
+        val duplicateId = TabId("accounts")
+        val tabs = listOf(
+            TabState(duplicateId, navigation(entry("accounts", Accounts))),
+            TabState(duplicateId, navigation(entry("cards", Cards))),
+        )
+
+        val problems = invalidProblems(TabNavigationState.fromTabs(duplicateId, tabs))
+
+        assertEquals(
+            listOf(
+                TabNavigationStateProblem.DuplicateTabId(
+                    tabId = duplicateId,
+                    firstIndex = 0,
+                    duplicateIndex = 1,
+                ),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `selected tab must belong to graph`() {
+        val tabs = listOf(
+            TabState(TabId("accounts"), navigation(entry("accounts", Accounts))),
+            TabState(TabId("cards"), navigation(entry("cards", Cards))),
+        )
+        val missingId = TabId("profile")
+
+        val problems = invalidProblems(TabNavigationState.fromTabs(missingId, tabs))
+
+        assertEquals(
+            listOf(TabNavigationStateProblem.SelectedTabNotFound(missingId)),
+            problems,
+        )
+    }
+
+    @Test
+    fun `entry identity is unique across the whole tab graph`() {
+        val duplicateEntryId = EntryId("shared-leaf")
+        val accountsId = TabId("accounts")
+        val cardsId = TabId("cards")
+        val tabs = listOf(
+            TabState(
+                accountsId,
+                navigation(
+                    entry("accounts-root", Accounts),
+                    entry(duplicateEntryId, Account(accountId = 1)),
+                ),
+            ),
+            TabState(
+                cardsId,
+                navigation(
+                    entry("cards-root", Cards),
+                    entry(duplicateEntryId, Card(cardId = 7)),
+                ),
+            ),
+        )
+
+        val problems = invalidProblems(TabNavigationState.fromTabs(accountsId, tabs))
+
+        assertEquals(
+            listOf(
+                TabNavigationStateProblem.DuplicateEntryId(
+                    entryId = duplicateEntryId,
+                    firstTabId = accountsId,
+                    duplicateTabId = cardsId,
+                    firstTabIndex = 0,
+                    duplicateTabIndex = 1,
+                ),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `graph owns a runtime-unmodifiable defensive copy of ordered tabs`() {
+        val accounts = TabState(
+            TabId("accounts"),
+            navigation(entry("accounts", Accounts)),
+        )
+        val cards = TabState(
+            TabId("cards"),
+            navigation(entry("cards", Cards)),
+        )
+        val source = mutableListOf(accounts, cards)
+        val graph = TabNavigationState.create(accounts.id, source)
+
+        source.clear()
+
+        assertEquals(listOf(accounts, cards), graph.tabs)
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (graph.tabs as MutableList<TabState>).add(
+                TabState(TabId("profile"), navigation(entry("profile", Home))),
+            )
+        }
+    }
+
+    @Test
+    fun `create reports invalid known configuration as programmer misuse`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            TabNavigationState.create(TabId("missing"), emptyList())
+        }
+
+        assertTrue(error.message.orEmpty().contains("EmptyTabs"))
+    }
+
+    @Test
+    fun `compound validation reports every problem in deterministic order`() {
+        val blankId = TabId(" ")
+        val sharedEntryId = EntryId("shared")
+        val tabs = listOf(
+            TabState(blankId, navigation(entry(sharedEntryId, Accounts))),
+            TabState(blankId, navigation(entry(sharedEntryId, Cards))),
+        )
+        val missingSelected = TabId("missing")
+
+        val problems = invalidProblems(
+            TabNavigationState.fromTabs(missingSelected, tabs),
+        )
+
+        assertEquals(
+            listOf(
+                TabNavigationStateProblem.BlankTabId(index = 0),
+                TabNavigationStateProblem.BlankTabId(index = 1),
+                TabNavigationStateProblem.DuplicateTabId(
+                    tabId = blankId,
+                    firstIndex = 0,
+                    duplicateIndex = 1,
+                ),
+                TabNavigationStateProblem.SelectedTabNotFound(missingSelected),
+                TabNavigationStateProblem.DuplicateEntryId(
+                    entryId = sharedEntryId,
+                    firstTabId = blankId,
+                    duplicateTabId = blankId,
+                    firstTabIndex = 0,
+                    duplicateTabIndex = 1,
+                ),
+            ),
+            problems,
+        )
+    }
+
+    private fun invalidProblems(
+        result: TabNavigationStateCreationResult,
+    ): List<TabNavigationStateProblem> = when (result) {
+        is TabNavigationStateCreationResult.Valid -> throw AssertionError(
+            "Expected invalid graph, got ${result.state}",
+        )
+        is TabNavigationStateCreationResult.Invalid -> result.problems
+    }
+
+    private fun navigation(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> throw AssertionError(result.problems)
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        entry(EntryId(id), route)
+
+    private fun entry(id: EntryId, route: Route): BackStackEntry =
+        BackStackEntry(id, route)
+}

--- a/docs/evidence/issue-42/README.md
+++ b/docs/evidence/issue-42/README.md
@@ -1,0 +1,46 @@
+# Issue #42 — immutable tab navigation graph model
+
+## Scope
+
+This slice adds only the pure Kotlin model for a stateful tab container. The existing single-stack
+runtime, Compose renderer, persistence, animation, and visible demo UI are unchanged.
+
+## TDD evidence
+
+1. The initial focused run failed at test compilation because `TabId`, `TabState`,
+   `TabNavigationState`, typed problems, and factories did not exist.
+2. The minimal model made the original eight Kotlin contracts and one Java contract pass.
+3. Consumer review exposed an awkward result-only happy path. Tests were changed first and failed
+   against the old API (`fromTabs`, direct `create`, `history`, and indexed diagnostics absent).
+4. The refined API and validation made the final focused suite pass: 10 Kotlin contracts and one
+   Java contract, 11/11 green.
+
+## Verified contracts
+
+- explicit selected `TabId` and deterministic tab-bar order;
+- independent exact `NavState` histories;
+- defensive, runtime-unmodifiable collections;
+- typed empty/blank/duplicate/missing-selection failures;
+- graph-wide `EntryId` ownership with both conflicting tab positions;
+- deterministic compound validation;
+- structural equality including selection and tab order;
+- direct `create` for known-valid application configuration;
+- typed `fromTabs` for restoration and other caller-controlled data;
+- Kotlin and Java consumption without demo-domain types in the core API.
+
+## Final verification
+
+```text
+./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest
+BUILD SUCCESSFUL
+
+JVM: 201 tests / 22 suites
+Failures: 0
+Errors: 0
+Skipped: 0
+```
+
+Architecture, test, and external-consumer re-reviews reported no P0, P1, or P2 findings.
+
+No device run or screenshot is attached because this slice changes no Android or visible UI
+behavior. Device evidence belongs to the later Compose tab-container child of #26.


### PR DESCRIPTION
## Summary

- add an immutable ordered `TabNavigationState` over independent leaf `NavState` histories
- expose a direct `create` happy path and typed `fromTabs` validation boundary for Kotlin and Java
- reject empty/ambiguous graphs and graph-wide `EntryId` collisions with actionable diagnostics
- document TDD and verification evidence

## Verification

- focused tab model API: 11/11
- `./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest`
- JVM: 201 tests / 22 suites, 0 failures, 0 errors, 0 skipped
- architecture, test, and external-consumer reviews: no P0/P1/P2 findings
- no emulator used because this slice changes no Android or visible UI behavior

Closes #42