### PR TITLE
Add typed tab navigation reducer and exact Back

### DIFF
--- a/app/src/main/java/com/shmakov/udf/navigation/TabNavigationReducer.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/TabNavigationReducer.kt
@@ -1,0 +1,475 @@
+package com.shmakov.udf.navigation
+
+import java.util.Collections
+
+/** A fully materialized operation on a [TabNavigationState]. */
+sealed class TabAction {
+
+    /** Selects an existing tab without changing any tab history. */
+    data class Select(
+        val tabId: TabId,
+    ) : TabAction()
+
+    /**
+     * Applies a leaf [NavAction] only while its originating tab and exact top are still current.
+     *
+     * The two guards make even an otherwise unguarded [NavAction.Pop] safe against callbacks that
+     * outlive a tab switch or a newer navigation state.
+     */
+    data class NavigateInSelectedTab(
+        val expectedSelectedTabId: TabId,
+        val expectedTopId: EntryId,
+        val action: NavAction,
+    ) : TabAction()
+
+    /**
+     * Atomically replaces one existing tab history and selects that tab.
+     *
+     * Every other tab is preserved. A missing tab, identity rebound, or graph collision leaves the
+     * complete graph and selection unchanged.
+     */
+    data class OpenTab(
+        val tabId: TabId,
+        val targetHistory: NavState,
+    ) : TabAction()
+
+    /**
+     * Atomically replaces the complete tab graph.
+     *
+     * A retained [EntryId] keeps its route. Full replacement may explicitly move the same
+     * ID-and-route occurrence between tabs; its UI identity follows the occurrence.
+     */
+    data class ReplaceGraph(
+        val target: TabNavigationState,
+    ) : TabAction()
+
+    /**
+     * Applies Back only while the selected tab and its exact visible top still match.
+     *
+     * Back at a tab root returns [TabUnchangedReason.ActiveTabAtRoot]; this reducer never selects a
+     * fallback tab or finishes an Android host.
+     */
+    data class Back(
+        val expectedSelectedTabId: TabId,
+        val expectedTopId: EntryId,
+    ) : TabAction()
+
+    companion object {
+        @JvmStatic
+        fun select(tabId: TabId): Select = Select(tabId)
+
+        @JvmStatic
+        fun navigateInSelectedTab(
+            expectedSelectedTabId: TabId,
+            expectedTopId: EntryId,
+            action: NavAction,
+        ): NavigateInSelectedTab = NavigateInSelectedTab(
+            expectedSelectedTabId,
+            expectedTopId,
+            action,
+        )
+
+        /** Captures exact selected-tab guards for an immediately materialized leaf action. */
+        @JvmStatic
+        fun navigateInSelectedTab(
+            state: TabNavigationState,
+            action: NavAction,
+        ): NavigateInSelectedTab = NavigateInSelectedTab(
+            expectedSelectedTabId = state.selectedTabId,
+            expectedTopId = state.selectedTab.history.top.id,
+            action = action,
+        )
+
+        @JvmStatic
+        fun openTab(tabId: TabId, targetHistory: NavState): OpenTab =
+            OpenTab(tabId, targetHistory)
+
+        @JvmStatic
+        fun replaceGraph(target: TabNavigationState): ReplaceGraph = ReplaceGraph(target)
+
+        /** Captures an exact Back action from the currently visible tab occurrence. */
+        @JvmStatic
+        fun back(state: TabNavigationState): Back = Back(
+            expectedSelectedTabId = state.selectedTabId,
+            expectedTopId = state.selectedTab.history.top.id,
+        )
+
+        @JvmStatic
+        fun back(expectedSelectedTabId: TabId, expectedTopId: EntryId): Back =
+            Back(expectedSelectedTabId, expectedTopId)
+    }
+}
+
+/** Semantic description of one applied tab-graph change. It is not durable state. */
+sealed class TabTransitionIntent {
+
+    data class TabSelected(
+        val previousTabId: TabId,
+        val selectedTabId: TabId,
+    ) : TabTransitionIntent()
+
+    data class NavigationChanged(
+        val tabId: TabId,
+        val navigationTransition: NavTransitionIntent,
+    ) : TabTransitionIntent()
+
+    /**
+     * One atomic target-history replacement and tab selection.
+     *
+     * [targetHistoryTransition] is measured inside the opened tab. It is `null` when that history
+     * was already equal and only selection changed; it must not be interpreted as the cross-tab
+     * visible transition described by [previousVisibleTopId] and [targetVisibleTopId].
+     */
+    data class TabOpened(
+        val previousSelectedTabId: TabId,
+        val openedTabId: TabId,
+        val previousVisibleTopId: EntryId,
+        val targetVisibleTopId: EntryId,
+        val targetHistoryTransition: NavTransitionIntent?,
+    ) : TabTransitionIntent()
+
+    data class GraphReplaced(
+        val previousSelectedTabId: TabId,
+        val selectedTabId: TabId,
+        val previousVisibleTopId: EntryId,
+        val targetVisibleTopId: EntryId,
+    ) : TabTransitionIntent()
+}
+
+/** The deterministic reason why a valid [TabAction] left the graph unchanged. */
+sealed class TabUnchangedReason {
+
+    data class TabNotFound(val tabId: TabId) : TabUnchangedReason()
+
+    data class AlreadySelected(val tabId: TabId) : TabUnchangedReason()
+
+    data class SelectedTabChanged(
+        val expectedSelectedTabId: TabId,
+        val actualSelectedTabId: TabId,
+    ) : TabUnchangedReason()
+
+    data class TopEntryChanged(
+        val tabId: TabId,
+        val expectedTopId: EntryId,
+        val actualTopId: EntryId,
+    ) : TabUnchangedReason()
+
+    data class NavigationUnchanged(
+        val tabId: TabId,
+        val reason: NavUnchangedReason,
+    ) : TabUnchangedReason()
+
+    class InvalidResultingGraph(
+        problems: List<TabNavigationStateProblem>,
+    ) : TabUnchangedReason() {
+        val problems: List<TabNavigationStateProblem> = immutableProblemListCopy(problems)
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is InvalidResultingGraph && problems == other.problems
+
+        override fun hashCode(): Int = problems.hashCode()
+
+        override fun toString(): String = "InvalidResultingGraph(problems=$problems)"
+    }
+
+    data class EntryIdentityRebound(
+        val entryId: EntryId,
+        val previousTabId: TabId,
+        val previousRoute: Route,
+        val targetTabId: TabId,
+        val targetRoute: Route,
+    ) : TabUnchangedReason()
+
+    data class ActiveTabAtRoot(
+        val tabId: TabId,
+        val rootEntryId: EntryId,
+    ) : TabUnchangedReason()
+
+    object AlreadyAtTarget : TabUnchangedReason()
+}
+
+/** Result of reducing one [TabAction]. */
+sealed class TabReduction {
+    abstract val state: TabNavigationState
+
+    data class Changed(
+        override val state: TabNavigationState,
+        val transition: TabTransitionIntent,
+    ) : TabReduction()
+
+    data class Unchanged(
+        override val state: TabNavigationState,
+        val reason: TabUnchangedReason,
+    ) : TabReduction()
+}
+
+/** Pure, deterministic reducer for a tab container and its independent leaf histories. */
+object TabReducer {
+
+    @JvmStatic
+    fun reduce(state: TabNavigationState, action: TabAction): TabReduction = when (action) {
+        is TabAction.Select -> select(state, action)
+        is TabAction.NavigateInSelectedTab -> navigateInSelectedTab(state, action)
+        is TabAction.OpenTab -> openTab(state, action)
+        is TabAction.ReplaceGraph -> replaceGraph(state, action)
+        is TabAction.Back -> back(state, action)
+    }
+
+    private fun select(
+        state: TabNavigationState,
+        action: TabAction.Select,
+    ): TabReduction {
+        if (state[action.tabId] == null) {
+            return state.unchanged(TabUnchangedReason.TabNotFound(action.tabId))
+        }
+        if (state.selectedTabId == action.tabId) {
+            return state.unchanged(TabUnchangedReason.AlreadySelected(action.tabId))
+        }
+
+        return TabReduction.Changed(
+            state = TabNavigationState.create(action.tabId, state.tabs),
+            transition = TabTransitionIntent.TabSelected(
+                previousTabId = state.selectedTabId,
+                selectedTabId = action.tabId,
+            ),
+        )
+    }
+
+    private fun navigateInSelectedTab(
+        state: TabNavigationState,
+        action: TabAction.NavigateInSelectedTab,
+    ): TabReduction {
+        val tab = state.guardedTab(action.expectedSelectedTabId, action.expectedTopId)
+            ?: return state.guardFailure(action.expectedSelectedTabId, action.expectedTopId)
+
+        return applyLeafReduction(
+            state = state,
+            tab = tab,
+            reduction = NavReducer.reduce(tab.history, action.action),
+        )
+    }
+
+    private fun openTab(
+        state: TabNavigationState,
+        action: TabAction.OpenTab,
+    ): TabReduction {
+        val tab = state[action.tabId]
+            ?: return state.unchanged(TabUnchangedReason.TabNotFound(action.tabId))
+
+        if (state.selectedTabId == action.tabId && tab.history == action.targetHistory) {
+            return state.unchanged(TabUnchangedReason.AlreadyAtTarget)
+        }
+
+        val previousVisibleTopId = state.selectedTab.history.top.id
+        return when (
+            val leafReduction = NavReducer.reduce(
+                tab.history,
+                NavAction.ReplaceHistory(action.targetHistory),
+            )
+        ) {
+            is NavReduction.Unchanged -> {
+                if (leafReduction.reason != NavUnchangedReason.AlreadyAtTarget) {
+                    state.unchanged(
+                        TabUnchangedReason.NavigationUnchanged(action.tabId, leafReduction.reason),
+                    )
+                } else {
+                    val selectedState = TabNavigationState.create(action.tabId, state.tabs)
+                    TabReduction.Changed(
+                        state = selectedState,
+                        transition = TabTransitionIntent.TabOpened(
+                            previousSelectedTabId = state.selectedTabId,
+                            openedTabId = action.tabId,
+                            previousVisibleTopId = previousVisibleTopId,
+                            targetVisibleTopId = selectedState.selectedTab.history.top.id,
+                            targetHistoryTransition = null,
+                        ),
+                    )
+                }
+            }
+
+            is NavReduction.Changed -> {
+                val candidate = state.withHistory(
+                    tabId = action.tabId,
+                    history = leafReduction.state,
+                    selectedTabId = action.tabId,
+                )
+                when (candidate) {
+                    is TabNavigationStateCreationResult.Invalid -> state.unchanged(
+                        TabUnchangedReason.InvalidResultingGraph(candidate.problems),
+                    )
+
+                    is TabNavigationStateCreationResult.Valid -> TabReduction.Changed(
+                        state = candidate.state,
+                        transition = TabTransitionIntent.TabOpened(
+                            previousSelectedTabId = state.selectedTabId,
+                            openedTabId = action.tabId,
+                            previousVisibleTopId = previousVisibleTopId,
+                            targetVisibleTopId = candidate.state.selectedTab.history.top.id,
+                            targetHistoryTransition = leafReduction.transition,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun replaceGraph(
+        state: TabNavigationState,
+        action: TabAction.ReplaceGraph,
+    ): TabReduction {
+        if (state == action.target) {
+            return state.unchanged(TabUnchangedReason.AlreadyAtTarget)
+        }
+
+        val previousOccurrences = state.ownedEntriesById()
+        action.target.tabs.forEach { targetTab ->
+            targetTab.history.entries.forEach entryLoop@{ targetEntry ->
+                val previous = previousOccurrences[targetEntry.id] ?: return@entryLoop
+                if (previous.entry.route != targetEntry.route) {
+                    return state.unchanged(
+                        TabUnchangedReason.EntryIdentityRebound(
+                            entryId = targetEntry.id,
+                            previousTabId = previous.tabId,
+                            previousRoute = previous.entry.route,
+                            targetTabId = targetTab.id,
+                            targetRoute = targetEntry.route,
+                        ),
+                    )
+                }
+            }
+        }
+
+        return TabReduction.Changed(
+            state = action.target,
+            transition = TabTransitionIntent.GraphReplaced(
+                previousSelectedTabId = state.selectedTabId,
+                selectedTabId = action.target.selectedTabId,
+                previousVisibleTopId = state.selectedTab.history.top.id,
+                targetVisibleTopId = action.target.selectedTab.history.top.id,
+            ),
+        )
+    }
+
+    private fun back(
+        state: TabNavigationState,
+        action: TabAction.Back,
+    ): TabReduction {
+        val tab = state.guardedTab(action.expectedSelectedTabId, action.expectedTopId)
+            ?: return state.guardFailure(action.expectedSelectedTabId, action.expectedTopId)
+
+        if (tab.history.entries.size == 1) {
+            return state.unchanged(
+                TabUnchangedReason.ActiveTabAtRoot(
+                    tabId = tab.id,
+                    rootEntryId = tab.history.root.id,
+                ),
+            )
+        }
+
+        val leafAction = if (tab.history.top.route is ModalRoute) {
+            NavAction.DismissModal(tab.history.top.id)
+        } else {
+            NavAction.Pop
+        }
+        return applyLeafReduction(
+            state = state,
+            tab = tab,
+            reduction = NavReducer.reduce(tab.history, leafAction),
+        )
+    }
+
+    private fun applyLeafReduction(
+        state: TabNavigationState,
+        tab: TabState,
+        reduction: NavReduction,
+    ): TabReduction = when (reduction) {
+        is NavReduction.Unchanged -> state.unchanged(
+            TabUnchangedReason.NavigationUnchanged(tab.id, reduction.reason),
+        )
+
+        is NavReduction.Changed -> when (
+            val candidate = state.withHistory(
+                tabId = tab.id,
+                history = reduction.state,
+                selectedTabId = state.selectedTabId,
+            )
+        ) {
+            is TabNavigationStateCreationResult.Invalid -> state.unchanged(
+                TabUnchangedReason.InvalidResultingGraph(candidate.problems),
+            )
+
+            is TabNavigationStateCreationResult.Valid -> TabReduction.Changed(
+                state = candidate.state,
+                transition = TabTransitionIntent.NavigationChanged(
+                    tabId = tab.id,
+                    navigationTransition = reduction.transition,
+                ),
+            )
+        }
+    }
+
+    private fun TabNavigationState.guardedTab(
+        expectedSelectedTabId: TabId,
+        expectedTopId: EntryId,
+    ): TabState? {
+        val tab = this[expectedSelectedTabId] ?: return null
+        if (selectedTabId != expectedSelectedTabId) return null
+        if (tab.history.top.id != expectedTopId) return null
+        return tab
+    }
+
+    private fun TabNavigationState.guardFailure(
+        expectedSelectedTabId: TabId,
+        expectedTopId: EntryId,
+    ): TabReduction.Unchanged {
+        val tab = this[expectedSelectedTabId]
+            ?: return unchanged(TabUnchangedReason.TabNotFound(expectedSelectedTabId))
+        if (selectedTabId != expectedSelectedTabId) {
+            return unchanged(
+                TabUnchangedReason.SelectedTabChanged(
+                    expectedSelectedTabId = expectedSelectedTabId,
+                    actualSelectedTabId = selectedTabId,
+                ),
+            )
+        }
+        return unchanged(
+            TabUnchangedReason.TopEntryChanged(
+                tabId = expectedSelectedTabId,
+                expectedTopId = expectedTopId,
+                actualTopId = tab.history.top.id,
+            ),
+        )
+    }
+
+    private fun TabNavigationState.withHistory(
+        tabId: TabId,
+        history: NavState,
+        selectedTabId: TabId,
+    ): TabNavigationStateCreationResult = TabNavigationState.fromTabs(
+        selectedTabId = selectedTabId,
+        tabs = tabs.map { tab ->
+            if (tab.id == tabId) TabState(tab.id, history) else tab
+        },
+    )
+
+    private fun TabNavigationState.ownedEntriesById(): Map<EntryId, OwnedEntry> = buildMap {
+        tabs.forEach { tab ->
+            tab.history.entries.forEach { entry ->
+                put(entry.id, OwnedEntry(tab.id, entry))
+            }
+        }
+    }
+
+    private fun TabNavigationState.unchanged(
+        reason: TabUnchangedReason,
+    ): TabReduction.Unchanged = TabReduction.Unchanged(this, reason)
+}
+
+private data class OwnedEntry(
+    val tabId: TabId,
+    val entry: BackStackEntry,
+)
+
+private fun immutableProblemListCopy(
+    source: Collection<TabNavigationStateProblem>,
+): List<TabNavigationStateProblem> = Collections.unmodifiableList(ArrayList(source))

--- a/app/src/test/java/com/shmakov/udf/navigation/TabNavigationReducerContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/navigation/TabNavigationReducerContractTest.kt
@@ -1,0 +1,691 @@
+package com.shmakov.udf.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TabNavigationReducerContractTest {
+
+    @Test
+    fun `select changes only selected tab and preserves every exact history`() {
+        val accounts = tab(
+            ACCOUNTS,
+            entry("accounts-root", Accounts),
+            entry("accounts-details", AccountDetails(accountId = 1)),
+        )
+        val cards = tab(
+            CARDS,
+            entry("cards-root", Cards),
+            entry("card-details", Card(cardId = 7)),
+        )
+        val initial = graph(ACCOUNTS, accounts, cards)
+
+        val result = changed(TabReducer.reduce(initial, TabAction.select(CARDS)))
+
+        assertEquals(CARDS, result.state.selectedTabId)
+        assertEquals(listOf(accounts, cards), result.state.tabs)
+        assertSame(accounts, result.state[ACCOUNTS])
+        assertSame(accounts.history, result.state[ACCOUNTS]?.history)
+        assertSame(cards, result.state[CARDS])
+        assertSame(cards.history, result.state[CARDS]?.history)
+        assertEquals(
+            TabTransitionIntent.TabSelected(
+                previousTabId = ACCOUNTS,
+                selectedTabId = CARDS,
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `reselect and unknown tab are typed no-ops`() {
+        val initial = graph(
+            ACCOUNTS,
+            tab(ACCOUNTS, entry("accounts-root", Accounts)),
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+
+        val reselect = unchanged(TabReducer.reduce(initial, TabAction.select(ACCOUNTS)))
+        val unknown = unchanged(TabReducer.reduce(initial, TabAction.select(TabId("unknown"))))
+
+        assertSame(initial, reselect.state)
+        assertEquals(TabUnchangedReason.AlreadySelected(ACCOUNTS), reselect.reason)
+        assertSame(initial, unknown.state)
+        assertEquals(
+            TabUnchangedReason.TabNotFound(TabId("unknown")),
+            unknown.reason,
+        )
+    }
+
+    @Test
+    fun `navigation in selected tab delegates to leaf reducer and preserves inactive tabs`() {
+        val accounts = tab(ACCOUNTS, entry("accounts-root", Accounts))
+        val cards = tab(CARDS, entry("cards-root", Cards))
+        val initial = graph(ACCOUNTS, accounts, cards)
+        val details = entry("account-details", AccountDetails(accountId = 1))
+        val leafAction = NavAction.Push(accounts.history.top.id, details)
+        val expectedLeaf = changed(NavReducer.reduce(accounts.history, leafAction))
+
+        val result = changed(
+            TabReducer.reduce(
+                initial,
+                TabAction.navigateInSelectedTab(
+                    expectedSelectedTabId = ACCOUNTS,
+                    expectedTopId = accounts.history.top.id,
+                    action = leafAction,
+                ),
+            ),
+        )
+
+        assertEquals(expectedLeaf.state, result.state[ACCOUNTS]?.history)
+        assertNotSame(accounts, result.state[ACCOUNTS])
+        assertSame(cards, result.state[CARDS])
+        assertSame(cards.history, result.state[CARDS]?.history)
+        assertEquals(ACCOUNTS, result.state.selectedTabId)
+        assertEquals(
+            TabTransitionIntent.NavigationChanged(
+                tabId = ACCOUNTS,
+                navigationTransition = expectedLeaf.transition,
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `leaf unchanged reason remains visible with exact original graph`() {
+        val duplicateId = EntryId("accounts-root")
+        val accounts = tab(ACCOUNTS, entry(duplicateId, Accounts))
+        val initial = graph(
+            ACCOUNTS,
+            accounts,
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+        val leafAction = NavAction.Push(
+            expectedTopId = accounts.history.top.id,
+            entry = entry(duplicateId, AccountDetails(accountId = 1)),
+        )
+
+        val result = unchanged(
+            TabReducer.reduce(
+                initial,
+                TabAction.navigateInSelectedTab(
+                    expectedSelectedTabId = ACCOUNTS,
+                    expectedTopId = accounts.history.top.id,
+                    action = leafAction,
+                ),
+            ),
+        )
+
+        assertSame(initial, result.state)
+        assertEquals(
+            TabUnchangedReason.NavigationUnchanged(
+                tabId = ACCOUNTS,
+                reason = NavUnchangedReason.EntryIdAlreadyExists(duplicateId),
+            ),
+            result.reason,
+        )
+    }
+
+    @Test
+    fun `callback from no longer selected tab cannot mutate either history`() {
+        val accounts = tab(
+            ACCOUNTS,
+            entry("accounts-root", Accounts),
+            entry("accounts-details", AccountDetails(accountId = 1)),
+        )
+        val cards = tab(
+            CARDS,
+            entry("cards-root", Cards),
+            entry("card-details", Card(cardId = 7)),
+        )
+        val selectedCards = graph(CARDS, accounts, cards)
+
+        val result = unchanged(
+            TabReducer.reduce(
+                selectedCards,
+                TabAction.navigateInSelectedTab(
+                    expectedSelectedTabId = ACCOUNTS,
+                    expectedTopId = EntryId("stale-accounts-top"),
+                    action = NavAction.Pop,
+                ),
+            ),
+        )
+
+        assertSame(selectedCards, result.state)
+        assertEquals(
+            TabUnchangedReason.SelectedTabChanged(
+                expectedSelectedTabId = ACCOUNTS,
+                actualSelectedTabId = CARDS,
+            ),
+            result.reason,
+        )
+        assertSame(accounts, result.state[ACCOUNTS])
+        assertSame(cards, result.state[CARDS])
+
+        val unknown = unchanged(
+            TabReducer.reduce(
+                selectedCards,
+                TabAction.navigateInSelectedTab(
+                    expectedSelectedTabId = TabId("unknown"),
+                    expectedTopId = EntryId("stale-unknown-top"),
+                    action = NavAction.Pop,
+                ),
+            ),
+        )
+        assertSame(selectedCards, unknown.state)
+        assertEquals(
+            TabUnchangedReason.TabNotFound(TabId("unknown")),
+            unknown.reason,
+        )
+    }
+
+    @Test
+    fun `callback with stale top cannot pop a replacement top in same tab`() {
+        val accounts = tab(
+            ACCOUNTS,
+            entry("accounts-root", Accounts),
+            entry("new-top", AccountDetails(accountId = 2)),
+        )
+        val initial = graph(
+            ACCOUNTS,
+            accounts,
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+
+        val result = unchanged(
+            TabReducer.reduce(
+                initial,
+                TabAction.navigateInSelectedTab(
+                    expectedSelectedTabId = ACCOUNTS,
+                    expectedTopId = EntryId("old-top"),
+                    action = NavAction.Pop,
+                ),
+            ),
+        )
+
+        assertSame(initial, result.state)
+        assertEquals(
+            TabUnchangedReason.TopEntryChanged(
+                tabId = ACCOUNTS,
+                expectedTopId = EntryId("old-top"),
+                actualTopId = accounts.history.top.id,
+            ),
+            result.reason,
+        )
+    }
+
+    @Test
+    fun `delegated navigation cannot claim entry identity owned by inactive tab`() {
+        val sharedId = EntryId("cards-root")
+        val cards = tab(CARDS, entry(sharedId, Cards))
+        val accounts = tab(ACCOUNTS, entry("accounts-root", Accounts))
+        val initial = graph(ACCOUNTS, cards, accounts)
+        val leafAction = NavAction.Push(
+            expectedTopId = accounts.history.top.id,
+            entry = entry(sharedId, AccountDetails(accountId = 1)),
+        )
+        assertTrue(NavReducer.reduce(accounts.history, leafAction) is NavReduction.Changed)
+
+        val result = unchanged(
+            TabReducer.reduce(
+                initial,
+                TabAction.navigateInSelectedTab(
+                    expectedSelectedTabId = ACCOUNTS,
+                    expectedTopId = accounts.history.top.id,
+                    action = leafAction,
+                ),
+            ),
+        )
+
+        val problem = TabNavigationStateProblem.DuplicateEntryId(
+            entryId = sharedId,
+            firstTabId = CARDS,
+            duplicateTabId = ACCOUNTS,
+            firstTabIndex = 0,
+            duplicateTabIndex = 1,
+        )
+        assertSame(initial, result.state)
+        assertEquals(
+            TabUnchangedReason.InvalidResultingGraph(listOf(problem)),
+            result.reason,
+        )
+    }
+
+    @Test
+    fun `open equal inactive history selects tab without rebuilding histories`() {
+        val accounts = tab(ACCOUNTS, entry("accounts-root", Accounts))
+        val cards = tab(
+            CARDS,
+            entry("cards-root", Cards),
+            entry("card-details", Card(cardId = 7)),
+        )
+        val initial = graph(ACCOUNTS, accounts, cards)
+
+        val result = changed(
+            TabReducer.reduce(initial, TabAction.openTab(CARDS, cards.history)),
+        )
+
+        assertEquals(CARDS, result.state.selectedTabId)
+        assertSame(accounts, result.state[ACCOUNTS])
+        assertSame(cards, result.state[CARDS])
+        assertEquals(
+            TabTransitionIntent.TabOpened(
+                previousSelectedTabId = ACCOUNTS,
+                openedTabId = CARDS,
+                previousVisibleTopId = accounts.history.top.id,
+                targetVisibleTopId = cards.history.top.id,
+                targetHistoryTransition = null,
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `open atomically replaces target history and selects its tab`() {
+        val accounts = tab(ACCOUNTS, entry("accounts-root", Accounts))
+        val cards = tab(CARDS, entry("cards-root", Cards))
+        val initial = graph(ACCOUNTS, accounts, cards)
+        val targetHistory = history(
+            entry("cards-root", Cards),
+            entry("card-7", Card(cardId = 7)),
+        )
+
+        val result = changed(
+            TabReducer.reduce(initial, TabAction.openTab(CARDS, targetHistory)),
+        )
+
+        assertEquals(CARDS, result.state.selectedTabId)
+        assertSame(accounts, result.state[ACCOUNTS])
+        assertSame(targetHistory, result.state[CARDS]?.history)
+        assertEquals(
+            TabTransitionIntent.TabOpened(
+                previousSelectedTabId = ACCOUNTS,
+                openedTabId = CARDS,
+                previousVisibleTopId = accounts.history.top.id,
+                targetVisibleTopId = targetHistory.top.id,
+                targetHistoryTransition = NavTransitionIntent.HistoryReplaced(
+                    previousTopEntryId = cards.history.top.id,
+                    targetTopEntryId = targetHistory.top.id,
+                ),
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `open no-op and failures never change selection or history`() {
+        val accounts = tab(ACCOUNTS, entry("accounts-root", Accounts))
+        val cards = tab(CARDS, entry("cards-root", Cards))
+        val initial = graph(ACCOUNTS, accounts, cards)
+
+        val alreadyOpen = unchanged(
+            TabReducer.reduce(initial, TabAction.openTab(ACCOUNTS, accounts.history)),
+        )
+        val unknown = unchanged(
+            TabReducer.reduce(initial, TabAction.openTab(TabId("unknown"), cards.history)),
+        )
+        val reboundTarget = history(entry("cards-root", Transactions))
+        val rebound = unchanged(
+            TabReducer.reduce(initial, TabAction.openTab(CARDS, reboundTarget)),
+        )
+        val collidingTarget = history(
+            entry("cards-root", Cards),
+            entry("accounts-root", AccountDetails(accountId = 1)),
+        )
+        val collision = unchanged(
+            TabReducer.reduce(initial, TabAction.openTab(CARDS, collidingTarget)),
+        )
+
+        assertSame(initial, alreadyOpen.state)
+        assertEquals(TabUnchangedReason.AlreadyAtTarget, alreadyOpen.reason)
+        assertSame(initial, unknown.state)
+        assertEquals(TabUnchangedReason.TabNotFound(TabId("unknown")), unknown.reason)
+        assertSame(initial, rebound.state)
+        assertEquals(
+            TabUnchangedReason.NavigationUnchanged(
+                tabId = CARDS,
+                reason = NavUnchangedReason.EntryIdentityRebound(
+                    entryId = EntryId("cards-root"),
+                    previousRoute = Cards,
+                    targetRoute = Transactions,
+                ),
+            ),
+            rebound.reason,
+        )
+        assertSame(initial, collision.state)
+        assertEquals(
+            TabUnchangedReason.InvalidResultingGraph(
+                listOf(
+                    TabNavigationStateProblem.DuplicateEntryId(
+                        entryId = EntryId("accounts-root"),
+                        firstTabId = ACCOUNTS,
+                        duplicateTabId = CARDS,
+                        firstTabIndex = 0,
+                        duplicateTabIndex = 1,
+                    ),
+                ),
+            ),
+            collision.reason,
+        )
+    }
+
+    @Test
+    fun `replace graph is atomic exact and protects retained route identity`() {
+        val initial = graph(
+            ACCOUNTS,
+            tab(ACCOUNTS, entry("accounts-root", Accounts)),
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+        val target = graph(
+            CARDS,
+            tab(ACCOUNTS, entry("new-accounts", Accounts)),
+            tab(CARDS, entry("new-cards", Cards)),
+        )
+
+        val changed = changed(TabReducer.reduce(initial, TabAction.replaceGraph(target)))
+        val equalTarget = graph(initial.selectedTabId, *initial.tabs.toTypedArray())
+        val equal = unchanged(
+            TabReducer.reduce(initial, TabAction.replaceGraph(equalTarget)),
+        )
+        val reboundTarget = graph(
+            ACCOUNTS,
+            tab(ACCOUNTS, entry("accounts-root", Transactions)),
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+        val rebound = unchanged(
+            TabReducer.reduce(initial, TabAction.replaceGraph(reboundTarget)),
+        )
+
+        assertSame(target, changed.state)
+        assertEquals(
+            TabTransitionIntent.GraphReplaced(
+                previousSelectedTabId = ACCOUNTS,
+                selectedTabId = CARDS,
+                previousVisibleTopId = EntryId("accounts-root"),
+                targetVisibleTopId = EntryId("new-cards"),
+            ),
+            changed.transition,
+        )
+        assertSame(initial, equal.state)
+        assertEquals(TabUnchangedReason.AlreadyAtTarget, equal.reason)
+        assertSame(initial, rebound.state)
+        assertEquals(
+            TabUnchangedReason.EntryIdentityRebound(
+                entryId = EntryId("accounts-root"),
+                previousTabId = ACCOUNTS,
+                previousRoute = Accounts,
+                targetTabId = ACCOUNTS,
+                targetRoute = Transactions,
+            ),
+            rebound.reason,
+        )
+    }
+
+    @Test
+    fun `replace graph may explicitly reparent same route occurrence`() {
+        val sharedId = EntryId("shared")
+        val initial = graph(
+            ACCOUNTS,
+            tab(ACCOUNTS, entry(sharedId, Accounts)),
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+        val target = graph(
+            CARDS,
+            tab(ACCOUNTS, entry("new-accounts", Home)),
+            tab(CARDS, entry(sharedId, Accounts)),
+        )
+
+        val result = changed(TabReducer.reduce(initial, TabAction.replaceGraph(target)))
+
+        assertSame(target, result.state)
+        assertEquals(sharedId, result.state[CARDS]?.history?.root?.id)
+    }
+
+    @Test
+    fun `Back pops exact content top only in selected tab`() {
+        val accounts = tab(
+            ACCOUNTS,
+            entry("accounts-root", Accounts),
+            entry("details", AccountDetails(accountId = 1)),
+        )
+        val cards = tab(CARDS, entry("cards-root", Cards))
+        val initial = graph(ACCOUNTS, accounts, cards)
+
+        val result = changed(TabReducer.reduce(initial, TabAction.back(initial)))
+
+        assertEquals(listOf(accounts.history.root), result.state[ACCOUNTS]?.history?.entries)
+        assertSame(cards, result.state[CARDS])
+        assertEquals(
+            TabTransitionIntent.NavigationChanged(
+                tabId = ACCOUNTS,
+                navigationTransition = NavTransitionIntent.Popped(
+                    removedEntryId = EntryId("details"),
+                    revealedEntryId = EntryId("accounts-root"),
+                ),
+            ),
+            result.transition,
+        )
+    }
+
+    @Test
+    fun `modal Back is exact and replay cannot pop underlying content`() {
+        val accounts = tab(
+            ACCOUNTS,
+            entry("accounts-root", Accounts),
+            entry("account-modal", Account(accountId = 1)),
+        )
+        val initial = graph(
+            ACCOUNTS,
+            accounts,
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+        val captured = TabAction.back(initial)
+
+        val first = changed(TabReducer.reduce(initial, captured))
+        val replay = unchanged(TabReducer.reduce(first.state, captured))
+
+        assertEquals(listOf(accounts.history.root), first.state[ACCOUNTS]?.history?.entries)
+        assertEquals(
+            TabTransitionIntent.NavigationChanged(
+                tabId = ACCOUNTS,
+                navigationTransition = NavTransitionIntent.ModalDismissed(EntryId("account-modal")),
+            ),
+            first.transition,
+        )
+        assertSame(first.state, replay.state)
+        assertEquals(
+            TabUnchangedReason.TopEntryChanged(
+                tabId = ACCOUNTS,
+                expectedTopId = EntryId("account-modal"),
+                actualTopId = EntryId("accounts-root"),
+            ),
+            replay.reason,
+        )
+    }
+
+    @Test
+    fun `Back at active root is explicit host fallthrough`() {
+        val accounts = tab(ACCOUNTS, entry("accounts-root", Accounts))
+        val cards = tab(
+            CARDS,
+            entry("cards-root", Cards),
+            entry("card-details", Card(cardId = 7)),
+        )
+        val initial = graph(ACCOUNTS, accounts, cards)
+
+        val result = unchanged(TabReducer.reduce(initial, TabAction.back(initial)))
+
+        assertSame(initial, result.state)
+        assertEquals(
+            TabUnchangedReason.ActiveTabAtRoot(
+                tabId = ACCOUNTS,
+                rootEntryId = accounts.history.root.id,
+            ),
+            result.reason,
+        )
+        assertSame(cards, result.state[CARDS])
+    }
+
+    @Test
+    fun `captured Back cannot pop replacement top in same tab`() {
+        val initial = graph(
+            ACCOUNTS,
+            tab(
+                ACCOUNTS,
+                entry("accounts-root", Accounts),
+                entry("old-top", AccountDetails(accountId = 1)),
+            ),
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+        val captured = TabAction.back(initial)
+        val replacement = graph(
+            ACCOUNTS,
+            tab(
+                ACCOUNTS,
+                entry("accounts-root", Accounts),
+                entry("new-top", AccountDetails(accountId = 2)),
+            ),
+            initial[CARDS]!!,
+        )
+
+        val result = unchanged(TabReducer.reduce(replacement, captured))
+
+        assertSame(replacement, result.state)
+        assertEquals(
+            TabUnchangedReason.TopEntryChanged(
+                tabId = ACCOUNTS,
+                expectedTopId = EntryId("old-top"),
+                actualTopId = EntryId("new-top"),
+            ),
+            result.reason,
+        )
+    }
+
+    @Test
+    fun `arbitrary fourth tab needs no reducer branch`() {
+        val supportId = TabId("support")
+        val accounts = tab(ACCOUNTS, entry("accounts-root", Accounts))
+        val cards = tab(CARDS, entry("cards-root", Cards))
+        val profile = tab(TabId("profile"), entry("profile-root", Home))
+        val support = tab(supportId, entry("support-root", SupportRoot))
+        val initial = graph(ACCOUNTS, accounts, cards, profile, support)
+
+        val selected = changed(TabReducer.reduce(initial, TabAction.select(supportId)))
+        val pushed = changed(
+            TabReducer.reduce(
+                selected.state,
+                TabAction.navigateInSelectedTab(
+                    expectedSelectedTabId = supportId,
+                    expectedTopId = support.history.top.id,
+                    action = NavAction.Push(
+                        support.history.top.id,
+                        entry("support-details", SupportDetails(topic = "state")),
+                    ),
+                ),
+            ),
+        )
+        val backed = changed(TabReducer.reduce(pushed.state, TabAction.back(pushed.state)))
+
+        assertEquals(support.history.entries, backed.state[supportId]?.history?.entries)
+        assertSame(accounts, backed.state[ACCOUNTS])
+        assertSame(cards, backed.state[CARDS])
+        assertSame(profile, backed.state[profile.id])
+        assertEquals(listOf(accounts, cards, profile, backed.state[supportId]), backed.state.tabs)
+    }
+
+    @Test
+    fun `invalid resulting graph reason owns unmodifiable defensive problems`() {
+        val source = mutableListOf<TabNavigationStateProblem>(
+            TabNavigationStateProblem.EmptyTabs,
+        )
+        val reason = TabUnchangedReason.InvalidResultingGraph(source)
+
+        source.clear()
+
+        assertEquals(listOf(TabNavigationStateProblem.EmptyTabs), reason.problems)
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (reason.problems as MutableList<TabNavigationStateProblem>).add(
+                TabNavigationStateProblem.SelectedTabNotFound(ACCOUNTS),
+            )
+        }
+    }
+
+    @Test
+    fun `action factories materialize explicit public values`() {
+        val graph = graph(
+            ACCOUNTS,
+            tab(ACCOUNTS, entry("accounts-root", Accounts)),
+            tab(CARDS, entry("cards-root", Cards)),
+        )
+        val leaf = NavAction.Pop
+
+        assertEquals(TabAction.Select(CARDS), TabAction.select(CARDS))
+        assertEquals(
+            TabAction.NavigateInSelectedTab(ACCOUNTS, EntryId("accounts-root"), leaf),
+            TabAction.navigateInSelectedTab(ACCOUNTS, EntryId("accounts-root"), leaf),
+        )
+        assertEquals(
+            TabAction.NavigateInSelectedTab(ACCOUNTS, EntryId("accounts-root"), leaf),
+            TabAction.navigateInSelectedTab(graph, leaf),
+        )
+        assertEquals(
+            TabAction.OpenTab(CARDS, graph[CARDS]!!.history),
+            TabAction.openTab(CARDS, graph[CARDS]!!.history),
+        )
+        assertEquals(TabAction.ReplaceGraph(graph), TabAction.replaceGraph(graph))
+        assertEquals(
+            TabAction.Back(ACCOUNTS, EntryId("accounts-root")),
+            TabAction.back(ACCOUNTS, EntryId("accounts-root")),
+        )
+        assertEquals(
+            TabAction.Back(ACCOUNTS, EntryId("accounts-root")),
+            TabAction.back(graph),
+        )
+    }
+
+    private fun changed(result: TabReduction): TabReduction.Changed {
+        assertTrue("Expected Changed, got $result", result is TabReduction.Changed)
+        return result as TabReduction.Changed
+    }
+
+    private fun unchanged(result: TabReduction): TabReduction.Unchanged {
+        assertTrue("Expected Unchanged, got $result", result is TabReduction.Unchanged)
+        return result as TabReduction.Unchanged
+    }
+
+    private fun changed(result: NavReduction): NavReduction.Changed {
+        assertTrue("Expected Changed, got $result", result is NavReduction.Changed)
+        return result as NavReduction.Changed
+    }
+
+    private fun graph(selectedTabId: TabId, vararg tabs: TabState): TabNavigationState =
+        TabNavigationState.create(selectedTabId, tabs.toList())
+
+    private fun tab(id: TabId, vararg entries: BackStackEntry): TabState =
+        TabState(id, history(*entries))
+
+    private fun history(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> throw AssertionError(result.problems)
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        entry(EntryId(id), route)
+
+    private fun entry(id: EntryId, route: Route): BackStackEntry =
+        BackStackEntry(id, route)
+
+    private data class SupportDetails(val topic: String) : ContentRoute
+
+    private object SupportRoot : ContentRoute
+
+    private companion object {
+        val ACCOUNTS = TabId("accounts")
+        val CARDS = TabId("cards")
+    }
+}

--- a/app/src/test/java/com/shmakov/udf/navigation/TabNavigationReducerJavaApiTest.java
+++ b/app/src/test/java/com/shmakov/udf/navigation/TabNavigationReducerJavaApiTest.java
@@ -1,0 +1,55 @@
+package com.shmakov.udf.navigation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public final class TabNavigationReducerJavaApiTest {
+
+    @Test
+    public void staticActionFactoriesAndReducerAreUsableWithoutCompanionSyntax() {
+        TabId accountsId = new TabId("accounts");
+        TabId cardsId = new TabId("cards");
+        TabState accounts = tab(accountsId, "accounts-root", Accounts.INSTANCE);
+        TabState cards = tab(cardsId, "cards-root", Cards.INSTANCE);
+        TabNavigationState graph = TabNavigationState.create(
+                accountsId,
+                Arrays.asList(accounts, cards)
+        );
+
+        TabAction.Select select = TabAction.select(cardsId);
+        TabAction.NavigateInSelectedTab navigate = TabAction.navigateInSelectedTab(
+                graph,
+                NavAction.pop()
+        );
+        TabAction.OpenTab open = TabAction.openTab(cardsId, cards.getHistory());
+        TabAction.ReplaceGraph replace = TabAction.replaceGraph(graph);
+        TabAction.Back backFromGraph = TabAction.back(graph);
+        TabAction.Back exactBack = TabAction.back(
+                accountsId,
+                accounts.getHistory().getTop().getId()
+        );
+
+        TabReduction reduction = TabReducer.reduce(graph, select);
+
+        assertTrue(reduction instanceof TabReduction.Changed);
+        assertEquals(cardsId, reduction.getState().getSelectedTabId());
+        assertEquals(accountsId, navigate.getExpectedSelectedTabId());
+        assertEquals(cardsId, open.getTabId());
+        assertEquals(graph, replace.getTarget());
+        assertEquals(exactBack, backFromGraph);
+    }
+
+    private static TabState tab(TabId id, String entryId, ContentRoute route) {
+        NavStateCreationResult result = NavState.fromEntries(
+                Collections.singletonList(
+                        new BackStackEntry(new EntryId(entryId), route)
+                )
+        );
+        assertTrue(result instanceof NavStateCreationResult.Valid);
+        return new TabState(id, ((NavStateCreationResult.Valid) result).getState());
+    }
+}

--- a/docs/evidence/issue-44/README.md
+++ b/docs/evidence/issue-44/README.md
@@ -1,0 +1,57 @@
+# Issue #44 — typed tab reducer and exact Back
+
+## Scope
+
+This slice adds pure Kotlin actions, reduction outcomes, transition metadata, and exact Back
+semantics on top of `TabNavigationState`. It does not integrate the graph into `AppStore`,
+persistence, Compose, or Android Back dispatch yet.
+
+## TDD evidence
+
+1. The complete Kotlin and Java contract suite was added before production types. Its first run
+   failed at compilation because `TabAction`, `TabReducer`, `TabReduction`, transition values, and
+   unchanged reasons did not exist.
+2. A minimal generic reducer made 19 Kotlin contracts and one Java contract pass.
+3. Review changed the tests first to require selected-tab naming, exact guard ergonomics, precise
+   transition coordinates, complete collision diagnostics, deterministic tab order, and guard
+   precedence. That run failed against the first API.
+4. The refined implementation made the final focused suite pass: 20/20.
+
+## Verified contracts
+
+- tab switching preserves every independent exact history and tab order;
+- reselect and unknown tab selection are typed no-ops;
+- leaf actions delegate to `NavReducer` only after selected-tab and exact-top guards;
+- stale outgoing-tab and stale same-tab callbacks cannot mutate newer state;
+- inactive-tab `EntryId` ownership remains protected after delegated navigation;
+- `OpenTab` atomically replaces one history and selects its tab;
+- `ReplaceGraph` atomically returns the exact target and rejects route identity rebound;
+- same `EntryId` and route can be explicitly reparented only through full graph replacement;
+- Back exact-pops content, exact-dismisses modal UI, is replay-safe, and exposes root fallthrough;
+- an arbitrary fourth application tab requires no reducer branch;
+- Kotlin and Java have static, boolean-free action factories;
+- all unchanged problem collections are defensive and runtime-unmodifiable.
+
+## Final verification
+
+```text
+Focused reducer API: 20/20
+
+./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest
+BUILD SUCCESSFUL
+
+./gradlew testDebugUnitTest --rerun-tasks
+BUILD SUCCESSFUL
+
+JVM: 221 tests / 24 suites
+Failures: 0
+Errors: 0
+Skipped: 0
+```
+
+The forced full JVM rerun prevents Gradle from treating earlier filtered test outputs as the full
+suite. Architecture, test, and external-consumer re-reviews reported no remaining P0, P1, or P2
+findings.
+
+No emulator or screenshot is attached because this slice changes no Android integration or visible
+UI behavior. Device evidence belongs to the later tab-container integration child of #26.


### PR DESCRIPTION
## Summary

- add generic typed tab actions and a pure reducer over independent `NavState` histories
- guard nested navigation with the expected selected tab and exact top entry
- add atomic `OpenTab` and full `ReplaceGraph` state replacement
- make Back exact, replay-safe, and explicit at tab root without hardcoded host policy
- cover Kotlin and Java consumer contracts with TDD evidence

## Verification

- focused tab reducer API: 20/20
- `./gradlew testDebugUnitTest lintDebug assembleDebug assembleDebugAndroidTest`
- forced full JVM: `./gradlew testDebugUnitTest --rerun-tasks`
- JVM: 221 tests / 24 suites, 0 failures, 0 errors, 0 skipped
- architecture, test, and external-consumer re-reviews: no P0/P1/P2 findings
- no emulator used because this slice changes no Android integration or visible UI behavior

Closes #44