### PR TITLE
Add versioned snapshot for the complete tab graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Navigation as state имеет смысл, только если модель н
 
 ## Основная идея
 
-Текущий navigation core хранит линейный `NavState.entries`. Каждый `BackStackEntry` содержит стабильный `EntryId` и semantic `Route`, поэтому два появления одного route остаются независимыми. Content- и modal-routes участвуют в одной истории, а чистый `NavProjector` преобразует её и явную `NavigationLayoutPolicy` в immutable `NavigationRenderTree`.
+Базовая единица navigation core — линейный `NavState.entries`. Каждый `BackStackEntry` содержит стабильный `EntryId` и semantic `Route`, поэтому два появления одного route остаются независимыми. Content- и modal-routes участвуют в одной истории, а чистый `NavProjector` преобразует её и явную `NavigationLayoutPolicy` в immutable `NavigationRenderTree`.
+
+Композиционный `TabNavigationState` добавляет ordered tab container поверх этих histories: он явно хранит выбранный `TabId`, отдельный валидный `NavState` каждого tab и graph-wide уникальность `EntryId`. Typed `TabReducer` переключает container, делегирует exact action выбранной history и атомарно заменяет tab/весь graph. Никакого скрытого `NavController` state у модели нет.
 
 Например, один и тот же state рендерится по-разному без изменения navigation history:
 
@@ -57,6 +59,7 @@ Navigation core уже содержит валидируемую entry model, с
 - semantic routes и независимую identity каждого back-stack entry;
 - непустой stack с content-root и уникальными entry IDs;
 - versioned snapshot и расширяемый route codec без Android/Compose dependencies;
+- immutable ordered tab graph, typed container/leaf actions и versioned snapshot всего graph;
 - typed push, pop, branch replacement, exact-ID modal dismiss и полную замену history;
 - чистый reducer с явными `Changed`/`Unchanged` outcomes;
 - transient transition intent, который не попадает в `NavState` или snapshot;
@@ -94,6 +97,28 @@ val snapshot = state.toSnapshot(DemoRouteCodec)
 ```
 
 Обычный код отдаёт генерацию identity фабрикам, а restoration и deep links могут передать заранее известные IDs через `NavState.fromEntries(...)`. Пользовательские routes реализуют ровно один из открытых интерфейсов `ContentRoute` или `ModalRoute` и подключают собственный `RouteCodec`.
+
+Tab graph использует тот же leaf API и тот же application-owned codec:
+
+```kotlin
+val graph = TabNavigationState.create(
+    selectedTabId = accounts.id,
+    tabs = listOf(accounts, cards),
+)
+
+when (val snapshotResult = graph.toSnapshot(routeCodec)) {
+    is TabNavigationSnapshotResult.Success ->
+        when (val restoreResult = TabNavigationState.restore(snapshotResult.value, routeCodec)) {
+            is TabNavigationSnapshotResult.Success -> useGraph(restoreResult.value)
+            is TabNavigationSnapshotResult.Failure ->
+                reportSnapshotProblems(restoreResult.problems)
+        }
+    is TabNavigationSnapshotResult.Failure ->
+        reportSnapshotProblems(snapshotResult.problems)
+}
+```
+
+Primitive `TabNavigationStateSnapshot` сохраняет selected tab, точный порядок tab-ов, все histories и exact IDs. `TabNavigationSnapshotResult` и `TabNavigationSnapshotProblem` отделены от leaf-result обычного `NavState`, поэтому новые graph diagnostics не добавляют невозможные ветви в leaf API. Он не содержит labels/icons, transition intent, animation, revision или Compose state. Это DTO, а не готовый `Bundle`/JSON transport: lifecycle/store интеграция всего graph будет отдельным этапом и только она сможет доказать recreation/process restoration.
 
 ## Чистая layout projection
 

--- a/app/src/main/java/com/shmakov/udf/navigation/TabNavigationState.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/TabNavigationState.kt
@@ -72,6 +72,10 @@ class TabNavigationState private constructor(
     /** Returns the tab with [tabId], or `null` when it does not belong to this graph. */
     operator fun get(tabId: TabId): TabState? = tabs.firstOrNull { it.id == tabId }
 
+    /** Encodes the selected tab and every ordered leaf history without Android or UI data. */
+    fun toSnapshot(codec: RouteCodec): TabNavigationSnapshotResult<TabNavigationStateSnapshot> =
+        snapshotTabNavigationState(this, codec)
+
     override fun equals(other: Any?): Boolean =
         this === other ||
             other is TabNavigationState &&
@@ -114,6 +118,14 @@ class TabNavigationState private constructor(
                 )
             }
         }
+
+        /** Restores the complete graph and reuses every leaf and graph invariant validator. */
+        @JvmStatic
+        fun restore(
+            snapshot: TabNavigationStateSnapshot,
+            codec: RouteCodec,
+        ): TabNavigationSnapshotResult<TabNavigationState> =
+            restoreTabNavigationState(snapshot, codec)
     }
 }
 

--- a/app/src/main/java/com/shmakov/udf/navigation/TabNavigationStateSnapshot.kt
+++ b/app/src/main/java/com/shmakov/udf/navigation/TabNavigationStateSnapshot.kt
@@ -1,0 +1,199 @@
+package com.shmakov.udf.navigation
+
+import java.util.Collections
+import java.util.LinkedHashMap
+
+/**
+ * Primitive, transport-agnostic representation of a complete [TabNavigationState].
+ *
+ * The outer version describes only this tab-container schema. Each [Tab.history] keeps its own
+ * [NavStateSnapshot.version], while application route payload versions remain part of route type
+ * keys. This DTO contains no labels, icons, transition intent, animation, revision, or Compose
+ * state. A transport and lifecycle owner are still required for process-death restoration.
+ */
+class TabNavigationStateSnapshot(
+    val version: Int,
+    val selectedTabId: String,
+    tabs: List<Tab>,
+) {
+    /** A defensive, runtime-unmodifiable copy in exact tab-bar order. */
+    val tabs: List<Tab> = immutableSnapshotTabListCopy(tabs)
+
+    /** Stable tab identity and its complete independent leaf history. */
+    data class Tab(
+        val id: String,
+        val history: NavStateSnapshot,
+    )
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is TabNavigationStateSnapshot &&
+            version == other.version &&
+            selectedTabId == other.selectedTabId &&
+            tabs == other.tabs
+
+    override fun hashCode(): Int {
+        var result = version
+        result = 31 * result + selectedTabId.hashCode()
+        result = 31 * result + tabs.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "TabNavigationStateSnapshot(version=$version, selectedTabId=$selectedTabId, tabs=$tabs)"
+
+    companion object {
+        const val CURRENT_VERSION: Int = 1
+    }
+}
+
+/** All-or-nothing result of encoding or restoring a complete tab navigation snapshot. */
+sealed class TabNavigationSnapshotResult<out T> {
+    data class Success<T>(val value: T) : TabNavigationSnapshotResult<T>()
+
+    data class Failure(
+        val problems: List<TabNavigationSnapshotProblem>,
+    ) : TabNavigationSnapshotResult<Nothing>()
+}
+
+/**
+ * A contextual tab snapshot failure.
+ *
+ * This family is deliberately non-sealed for consumers: application code should keep a fallback
+ * branch so future version or migration diagnostics can be added without breaking source.
+ */
+abstract class TabNavigationSnapshotProblem private constructor() {
+    /** The outer tab-container schema version is not supported. */
+    data class UnsupportedVersion(val version: Int) : TabNavigationSnapshotProblem()
+
+    /** A leaf [NavStateSnapshot] problem enriched with its exact tab location. */
+    data class HistoryProblem(
+        val tabIndex: Int,
+        val tabId: String,
+        val problem: SnapshotProblem,
+    ) : TabNavigationSnapshotProblem()
+
+    /** Restored leaf histories violate a whole-[TabNavigationState] invariant. */
+    data class InvalidState(
+        val problem: TabNavigationStateProblem,
+    ) : TabNavigationSnapshotProblem()
+}
+
+@JvmSynthetic
+internal fun snapshotTabNavigationState(
+    state: TabNavigationState,
+    codec: RouteCodec,
+): TabNavigationSnapshotResult<TabNavigationStateSnapshot> {
+    val problems = mutableListOf<TabNavigationSnapshotProblem>()
+    val snapshotTabs = mutableListOf<TabNavigationStateSnapshot.Tab>()
+
+    state.tabs.forEachIndexed { tabIndex, tab ->
+        when (val result = tab.history.toSnapshot(codec)) {
+            is SnapshotResult.Success -> snapshotTabs += TabNavigationStateSnapshot.Tab(
+                id = tab.id.value,
+                history = result.value,
+            )
+            is SnapshotResult.Failure -> problems += result.problems.map { problem ->
+                TabNavigationSnapshotProblem.HistoryProblem(
+                    tabIndex = tabIndex,
+                    tabId = tab.id.value,
+                    problem = problem,
+                )
+            }
+        }
+    }
+
+    return if (problems.isEmpty()) {
+        TabNavigationSnapshotResult.Success(
+            TabNavigationStateSnapshot(
+                version = TabNavigationStateSnapshot.CURRENT_VERSION,
+                selectedTabId = state.selectedTabId.value,
+                tabs = snapshotTabs,
+            ),
+        )
+    } else {
+        TabNavigationSnapshotResult.Failure(immutableTabSnapshotProblemListCopy(problems))
+    }
+}
+
+@JvmSynthetic
+internal fun restoreTabNavigationState(
+    snapshot: TabNavigationStateSnapshot,
+    codec: RouteCodec,
+): TabNavigationSnapshotResult<TabNavigationState> {
+    if (snapshot.version != TabNavigationStateSnapshot.CURRENT_VERSION) {
+        return TabNavigationSnapshotResult.Failure(
+            listOf(TabNavigationSnapshotProblem.UnsupportedVersion(snapshot.version)),
+        )
+    }
+
+    val problems = mutableListOf<TabNavigationSnapshotProblem>()
+    val restoredTabs = mutableListOf<TabState>()
+    val snapshotTabs = ArrayList(snapshot.tabs)
+
+    snapshotTabs.forEachIndexed { tabIndex, snapshotTab ->
+        when (val result = NavState.restore(snapshotTab.history, codec)) {
+            is SnapshotResult.Success -> restoredTabs += TabState(
+                id = TabId(snapshotTab.id),
+                history = result.value,
+            )
+            is SnapshotResult.Failure -> problems += result.problems.map { problem ->
+                TabNavigationSnapshotProblem.HistoryProblem(
+                    tabIndex = tabIndex,
+                    tabId = snapshotTab.id,
+                    problem = problem,
+                )
+            }
+        }
+    }
+
+    if (problems.isNotEmpty()) {
+        return TabNavigationSnapshotResult.Failure(
+            immutableTabSnapshotProblemListCopy(problems),
+        )
+    }
+
+    return when (
+        val result = TabNavigationState.fromTabs(
+            selectedTabId = TabId(snapshot.selectedTabId),
+            tabs = restoredTabs,
+        )
+    ) {
+        is TabNavigationStateCreationResult.Valid ->
+            TabNavigationSnapshotResult.Success(result.state)
+        is TabNavigationStateCreationResult.Invalid -> TabNavigationSnapshotResult.Failure(
+            immutableTabSnapshotProblemListCopy(
+                result.problems.map(TabNavigationSnapshotProblem::InvalidState),
+            ),
+        )
+    }
+}
+
+private fun immutableSnapshotTabListCopy(
+    source: Collection<TabNavigationStateSnapshot.Tab>,
+): List<TabNavigationStateSnapshot.Tab> = Collections.unmodifiableList(
+    source.mapTo(ArrayList(source.size)) { tab ->
+        TabNavigationStateSnapshot.Tab(
+            id = tab.id,
+            history = immutableNavStateSnapshotCopy(tab.history),
+        )
+    },
+)
+
+private fun immutableNavStateSnapshotCopy(snapshot: NavStateSnapshot): NavStateSnapshot =
+    NavStateSnapshot(
+        version = snapshot.version,
+        entries = Collections.unmodifiableList(
+            snapshot.entries.mapTo(ArrayList(snapshot.entries.size)) { entry ->
+                NavStateSnapshot.Entry(
+                    id = entry.id,
+                    routeType = entry.routeType,
+                    arguments = Collections.unmodifiableMap(LinkedHashMap(entry.arguments)),
+                )
+            },
+        ),
+    )
+
+private fun immutableTabSnapshotProblemListCopy(
+    source: Collection<TabNavigationSnapshotProblem>,
+): List<TabNavigationSnapshotProblem> = Collections.unmodifiableList(ArrayList(source))

--- a/app/src/test/java/com/shmakov/udf/navigation/TabNavigationSnapshotContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/navigation/TabNavigationSnapshotContractTest.kt
@@ -1,0 +1,775 @@
+package com.shmakov.udf.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TabNavigationSnapshotContractTest {
+
+    @Test
+    fun `wire shape and round trip preserve selected tab ordered histories and exact IDs`() {
+        val accounts = tab(
+            "accounts",
+            entry("accounts-root", Accounts),
+            entry("account-42", Account(accountId = 42)),
+        )
+        val cards = tab(
+            "cards",
+            entry("cards-root", Cards),
+            entry("card-7", Card(cardId = 7)),
+        )
+        val original = TabNavigationState.create(cards.id, listOf(accounts, cards))
+
+        val snapshot = snapshotSuccess(original.toSnapshot(DemoRouteCodec))
+        val repeatedSnapshot = snapshotSuccess(original.toSnapshot(DemoRouteCodec))
+
+        assertEquals(TabNavigationStateSnapshot.CURRENT_VERSION, snapshot.version)
+        assertEquals("cards", snapshot.selectedTabId)
+        assertEquals(
+            listOf(
+                TabNavigationStateSnapshot.Tab(
+                    id = "accounts",
+                    history = NavStateSnapshot(
+                        version = NavStateSnapshot.CURRENT_VERSION,
+                        entries = listOf(
+                            snapshotEntry("accounts-root", "accounts/v1"),
+                            snapshotEntry("account-42", "account/v1", "accountId" to "42"),
+                        ),
+                    ),
+                ),
+                TabNavigationStateSnapshot.Tab(
+                    id = "cards",
+                    history = NavStateSnapshot(
+                        version = NavStateSnapshot.CURRENT_VERSION,
+                        entries = listOf(
+                            snapshotEntry("cards-root", "cards/v1"),
+                            snapshotEntry("card-7", "card/v1", "cardId" to "7"),
+                        ),
+                    ),
+                ),
+            ),
+            snapshot.tabs,
+        )
+        assertEquals(snapshot, repeatedSnapshot)
+
+        val restored = restoreSuccess(
+            TabNavigationState.restore(snapshot, DemoRouteCodec),
+        )
+
+        assertEquals(original, restored)
+        assertNotSame(original, restored)
+        original.tabs.zip(restored.tabs).forEach { (originalTab, restoredTab) ->
+            assertNotSame(originalTab.history, restoredTab.history)
+        }
+        assertEquals(
+            original.tabs.map { tab -> tab.id to tab.history.entries.map { it.id } },
+            restored.tabs.map { tab -> tab.id to tab.history.entries.map { it.id } },
+        )
+    }
+
+    @Test
+    fun `unsupported outer version fails before codec is called`() {
+        val codec = RecordingCodec()
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION + 1,
+            selectedTabId = "accounts",
+            tabs = listOf(
+                TabNavigationStateSnapshot.Tab(
+                    id = "accounts",
+                    history = leafSnapshot("accounts-root", "accounts/v1"),
+                ),
+            ),
+        )
+
+        val problems = snapshotFailure(TabNavigationState.restore(snapshot, codec))
+
+        assertEquals(
+            listOf(TabNavigationSnapshotProblem.UnsupportedVersion(snapshot.version)),
+            problems,
+        )
+        assertEquals(0, codec.decodeCalls)
+    }
+
+    @Test
+    fun `nested decode failure keeps exact tab and entry context`() {
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "cards",
+            tabs = listOf(
+                TabNavigationStateSnapshot.Tab(
+                    id = "accounts",
+                    history = leafSnapshot("accounts-root", "accounts/v1"),
+                ),
+                TabNavigationStateSnapshot.Tab(
+                    id = "cards",
+                    history = NavStateSnapshot(
+                        version = NavStateSnapshot.CURRENT_VERSION,
+                        entries = listOf(
+                            snapshotEntry("cards-root", "cards/v1"),
+                            snapshotEntry("broken-card", "card/broken"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val problem = snapshotFailure(
+            TabNavigationState.restore(snapshot, DemoRouteCodec),
+        ).single()
+
+        assertEquals(
+            TabNavigationSnapshotProblem.HistoryProblem(
+                tabIndex = 1,
+                tabId = "cards",
+                problem = SnapshotProblem.RouteDecodeFailed(
+                    index = 1,
+                    entryId = "broken-card",
+                    routeType = "card/broken",
+                    error = RouteCodecError(
+                        code = "unknown_route_type",
+                        message = "Unknown route type: card/broken",
+                    ),
+                ),
+            ),
+            problem,
+        )
+    }
+
+    @Test
+    fun `cross-tab duplicate entry ID is rejected by shared graph validation`() {
+        val sharedId = "shared"
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "accounts",
+            tabs = listOf(
+                TabNavigationStateSnapshot.Tab(
+                    id = "accounts",
+                    history = leafSnapshot(sharedId, "accounts/v1"),
+                ),
+                TabNavigationStateSnapshot.Tab(
+                    id = "cards",
+                    history = leafSnapshot(sharedId, "cards/v1"),
+                ),
+            ),
+        )
+
+        val problems = snapshotFailure(
+            TabNavigationState.restore(snapshot, DemoRouteCodec),
+        )
+
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotProblem.InvalidState(
+                    TabNavigationStateProblem.DuplicateEntryId(
+                        entryId = EntryId(sharedId),
+                        firstTabId = TabId("accounts"),
+                        duplicateTabId = TabId("cards"),
+                        firstTabIndex = 0,
+                        duplicateTabIndex = 1,
+                    ),
+                ),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `application codec round trips routes in multiple arbitrary tabs`() {
+        val first = tab(
+            "first",
+            entry("first-root", ConsumerRoute("first-root")),
+            entry("first-details", ConsumerRoute("first-details")),
+        )
+        val second = tab(
+            "second",
+            entry("second-root", ConsumerRoute("second-root")),
+        )
+        val original = TabNavigationState.create(second.id, listOf(first, second))
+
+        val snapshot = snapshotSuccess(original.toSnapshot(ConsumerCodec))
+        val restored = restoreSuccess(TabNavigationState.restore(snapshot, ConsumerCodec))
+
+        assertEquals(listOf("first", "second"), snapshot.tabs.map { it.id })
+        assertEquals(
+            listOf("first-root", "first-details", "second-root"),
+            snapshot.tabs.flatMap { tab -> tab.history.entries.map { it.arguments["slug"] } },
+        )
+        assertEquals(original, restored)
+        assertEquals(
+            original.tabs.flatMap { tab -> tab.history.entries.map { it.id } },
+            restored.tabs.flatMap { tab -> tab.history.entries.map { it.id } },
+        )
+    }
+
+    @Test
+    fun `multiple encode failures are tab-major then entry-major with exact context`() {
+        val original = TabNavigationState.create(
+            selectedTabId = TabId("accounts"),
+            tabs = listOf(
+                tab(
+                    "accounts",
+                    entry("accounts-root", ConsumerRoute("accounts-root")),
+                    entry("accounts-bad", UnsupportedConsumerRoute("accounts-bad")),
+                ),
+                tab("cards", entry("cards-root", ConsumerRoute("cards-root"))),
+                tab(
+                    "support",
+                    entry("support-bad-root", UnsupportedConsumerRoute("support-root")),
+                    entry("support-good", ConsumerRoute("support-good")),
+                    entry("support-bad-details", UnsupportedConsumerRoute("support-details")),
+                ),
+            ),
+        )
+
+        val problems = snapshotFailure(original.toSnapshot(ConsumerCodec))
+
+        assertEquals(
+            listOf(
+                encodeProblem(0, "accounts", 1, "accounts-bad", "accounts-bad"),
+                encodeProblem(2, "support", 0, "support-bad-root", "support-root"),
+                encodeProblem(2, "support", 2, "support-bad-details", "support-details"),
+            ),
+            problems,
+        )
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (problems as MutableList<TabNavigationSnapshotProblem>).clear()
+        }
+    }
+
+    @Test
+    fun `multiple decode failures are tab-major then entry-major with exact context`() {
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "accounts",
+            tabs = listOf(
+                snapshotTab(
+                    "accounts",
+                    snapshotEntry("accounts-root", "consumer/v1", "slug" to "accounts-root"),
+                    snapshotEntry("accounts-bad", "bad/accounts"),
+                ),
+                snapshotTab(
+                    "support",
+                    snapshotEntry("support-bad-root", "bad/support-root"),
+                    snapshotEntry("support-good", "consumer/v1", "slug" to "support-good"),
+                    snapshotEntry("support-bad-details", "bad/support-details"),
+                ),
+            ),
+        )
+
+        val problems = snapshotFailure(TabNavigationState.restore(snapshot, ConsumerCodec))
+
+        assertEquals(
+            listOf(
+                decodeProblem(0, "accounts", 1, "accounts-bad", "bad/accounts"),
+                decodeProblem(1, "support", 0, "support-bad-root", "bad/support-root"),
+                decodeProblem(1, "support", 2, "support-bad-details", "bad/support-details"),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `codec exceptions keep exact tab and leaf context`() {
+        val graph = TabNavigationState.create(
+            selectedTabId = TabId("accounts"),
+            tabs = listOf(tab("accounts", entry("accounts-root", Accounts))),
+        )
+        val encodeProblems = snapshotFailure(graph.toSnapshot(ThrowingEncodeCodec))
+        val decodeSnapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "accounts",
+            tabs = listOf(snapshotTab("accounts", snapshotEntry("accounts-root", "accounts/v1"))),
+        )
+        val decodeProblems = snapshotFailure(
+            TabNavigationState.restore(decodeSnapshot, ThrowingDecodeCodec),
+        )
+
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotProblem.HistoryProblem(
+                    tabIndex = 0,
+                    tabId = "accounts",
+                    problem = SnapshotProblem.RouteEncodeFailed(
+                        index = 0,
+                        entryId = EntryId("accounts-root"),
+                        error = RouteCodecError("codec_exception", "encode boom"),
+                    ),
+                ),
+            ),
+            encodeProblems,
+        )
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotProblem.HistoryProblem(
+                    tabIndex = 0,
+                    tabId = "accounts",
+                    problem = SnapshotProblem.RouteDecodeFailed(
+                        index = 0,
+                        entryId = "accounts-root",
+                        routeType = "accounts/v1",
+                        error = RouteCodecError("codec_exception", "decode boom"),
+                    ),
+                ),
+            ),
+            decodeProblems,
+        )
+    }
+
+    @Test
+    fun `nested version and leaf state failures keep ordered tab context`() {
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "accounts",
+            tabs = listOf(
+                TabNavigationStateSnapshot.Tab(
+                    id = "accounts",
+                    history = NavStateSnapshot(
+                        version = NavStateSnapshot.CURRENT_VERSION + 1,
+                        entries = listOf(snapshotEntry("accounts-root", "accounts/v1")),
+                    ),
+                ),
+                TabNavigationStateSnapshot.Tab(
+                    id = "cards",
+                    history = NavStateSnapshot(
+                        version = NavStateSnapshot.CURRENT_VERSION,
+                        entries = emptyList(),
+                    ),
+                ),
+                snapshotTab("blank", snapshotEntry(" ", "home/v1")),
+                snapshotTab(
+                    "duplicate",
+                    snapshotEntry("duplicate-entry", "home/v1"),
+                    snapshotEntry("duplicate-entry", "accounts/v1"),
+                ),
+            ),
+        )
+
+        val problems = snapshotFailure(TabNavigationState.restore(snapshot, DemoRouteCodec))
+
+        assertEquals(
+            listOf(
+                tabProblem(0, "accounts", SnapshotProblem.UnsupportedVersion(2)),
+                tabProblem(
+                    1,
+                    "cards",
+                    SnapshotProblem.InvalidState(NavStateProblem.EmptyStack),
+                ),
+                tabProblem(
+                    2,
+                    "blank",
+                    SnapshotProblem.InvalidState(NavStateProblem.BlankEntryId(index = 0)),
+                ),
+                tabProblem(
+                    3,
+                    "duplicate",
+                    SnapshotProblem.InvalidState(
+                        NavStateProblem.DuplicateEntryId(EntryId("duplicate-entry")),
+                    ),
+                ),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `empty blank duplicate and missing selection snapshots reuse graph validation`() {
+        val validLeaf = leafSnapshot("root", "home/v1")
+        val cases = listOf(
+            CorruptGraphCase(
+                snapshot = TabNavigationStateSnapshot(
+                    version = TabNavigationStateSnapshot.CURRENT_VERSION,
+                    selectedTabId = "missing",
+                    tabs = emptyList(),
+                ),
+                expected = TabNavigationStateProblem.EmptyTabs,
+            ),
+            CorruptGraphCase(
+                snapshot = TabNavigationStateSnapshot(
+                    version = TabNavigationStateSnapshot.CURRENT_VERSION,
+                    selectedTabId = " ",
+                    tabs = listOf(TabNavigationStateSnapshot.Tab(" ", validLeaf)),
+                ),
+                expected = TabNavigationStateProblem.BlankTabId(index = 0),
+            ),
+            CorruptGraphCase(
+                snapshot = TabNavigationStateSnapshot(
+                    version = TabNavigationStateSnapshot.CURRENT_VERSION,
+                    selectedTabId = "duplicate",
+                    tabs = listOf(
+                        TabNavigationStateSnapshot.Tab("duplicate", leafSnapshot("first", "home/v1")),
+                        TabNavigationStateSnapshot.Tab("duplicate", leafSnapshot("second", "home/v1")),
+                    ),
+                ),
+                expected = TabNavigationStateProblem.DuplicateTabId(
+                    tabId = TabId("duplicate"),
+                    firstIndex = 0,
+                    duplicateIndex = 1,
+                ),
+            ),
+            CorruptGraphCase(
+                snapshot = TabNavigationStateSnapshot(
+                    version = TabNavigationStateSnapshot.CURRENT_VERSION,
+                    selectedTabId = "missing",
+                    tabs = listOf(TabNavigationStateSnapshot.Tab("accounts", validLeaf)),
+                ),
+                expected = TabNavigationStateProblem.SelectedTabNotFound(TabId("missing")),
+            ),
+        )
+
+        cases.forEach { case ->
+            assertEquals(
+                listOf(TabNavigationSnapshotProblem.InvalidState(case.expected)),
+                snapshotFailure(TabNavigationState.restore(case.snapshot, DemoRouteCodec)),
+            )
+        }
+    }
+
+    @Test
+    fun `compound graph corruption preserves deterministic model problem order`() {
+        val sharedId = "shared"
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "missing",
+            tabs = listOf(
+                TabNavigationStateSnapshot.Tab(" ", leafSnapshot(sharedId, "accounts/v1")),
+                TabNavigationStateSnapshot.Tab(" ", leafSnapshot(sharedId, "cards/v1")),
+            ),
+        )
+
+        val problems = snapshotFailure(TabNavigationState.restore(snapshot, DemoRouteCodec))
+
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotProblem.InvalidState(
+                    TabNavigationStateProblem.BlankTabId(index = 0),
+                ),
+                TabNavigationSnapshotProblem.InvalidState(
+                    TabNavigationStateProblem.BlankTabId(index = 1),
+                ),
+                TabNavigationSnapshotProblem.InvalidState(
+                    TabNavigationStateProblem.DuplicateTabId(TabId(" "), 0, 1),
+                ),
+                TabNavigationSnapshotProblem.InvalidState(
+                    TabNavigationStateProblem.SelectedTabNotFound(TabId("missing")),
+                ),
+                TabNavigationSnapshotProblem.InvalidState(
+                    TabNavigationStateProblem.DuplicateEntryId(
+                        entryId = EntryId(sharedId),
+                        firstTabId = TabId(" "),
+                        duplicateTabId = TabId(" "),
+                        firstTabIndex = 0,
+                        duplicateTabIndex = 1,
+                    ),
+                ),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `child failures precede and suppress graph validation phase`() {
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "missing",
+            tabs = listOf(
+                snapshotTab("duplicate", snapshotEntry("broken", "unknown/v1")),
+                snapshotTab("duplicate", snapshotEntry("valid", "home/v1")),
+            ),
+        )
+
+        val problems = snapshotFailure(TabNavigationState.restore(snapshot, DemoRouteCodec))
+
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotProblem.HistoryProblem(
+                    tabIndex = 0,
+                    tabId = "duplicate",
+                    problem = SnapshotProblem.RouteDecodeFailed(
+                        index = 0,
+                        entryId = "broken",
+                        routeType = "unknown/v1",
+                        error = RouteCodecError(
+                            code = "unknown_route_type",
+                            message = "Unknown route type: unknown/v1",
+                        ),
+                    ),
+                ),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `snapshot deeply owns immutable lists maps and structural order`() {
+        val arguments = linkedMapOf("slug" to "root")
+        val entries = mutableListOf(
+            NavStateSnapshot.Entry("first-root", "consumer/v1", arguments),
+        )
+        val sourceTabs = mutableListOf(
+            TabNavigationStateSnapshot.Tab(
+                "first",
+                NavStateSnapshot(NavStateSnapshot.CURRENT_VERSION, entries),
+            ),
+            snapshotTab("second", snapshotEntry("second-root", "home/v1")),
+        )
+        val snapshot = TabNavigationStateSnapshot(
+            TabNavigationStateSnapshot.CURRENT_VERSION,
+            "first",
+            sourceTabs,
+        )
+        val equalSnapshot = TabNavigationStateSnapshot(
+            TabNavigationStateSnapshot.CURRENT_VERSION,
+            "first",
+            listOf(
+                snapshotTab(
+                    "first",
+                    snapshotEntry("first-root", "consumer/v1", "slug" to "root"),
+                ),
+                snapshotTab("second", snapshotEntry("second-root", "home/v1")),
+            ),
+        )
+        val reversed = TabNavigationStateSnapshot(
+            TabNavigationStateSnapshot.CURRENT_VERSION,
+            "first",
+            equalSnapshot.tabs.reversed(),
+        )
+
+        sourceTabs.clear()
+        entries.clear()
+        arguments.clear()
+
+        assertEquals(equalSnapshot, snapshot)
+        assertEquals(equalSnapshot.hashCode(), snapshot.hashCode())
+        assertNotEquals(snapshot, reversed)
+        assertEquals("root", snapshot.tabs.first().history.entries.single().arguments["slug"])
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (snapshot.tabs as MutableList<TabNavigationStateSnapshot.Tab>).clear()
+        }
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (snapshot.tabs.first().history.entries as MutableList<NavStateSnapshot.Entry>).clear()
+        }
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (snapshot.tabs.first().history.entries.single().arguments as MutableMap<String, String>)["x"] = "y"
+        }
+    }
+
+    @Test
+    fun `snapshot equality contains durable graph state but no transition metadata`() {
+        val accounts = tab("accounts", entry("accounts-root", Accounts))
+        val cards = tab("cards", entry("cards-root", Cards))
+        val initial = TabNavigationState.create(accounts.id, listOf(accounts, cards))
+        val changed = TabReducer.reduce(initial, TabAction.select(cards.id)) as TabReduction.Changed
+        val durableEquivalent = TabNavigationState.create(cards.id, listOf(accounts, cards))
+
+        val changedSnapshot = snapshotSuccess(changed.state.toSnapshot(DemoRouteCodec))
+        val durableSnapshot = snapshotSuccess(durableEquivalent.toSnapshot(DemoRouteCodec))
+        assertEquals(durableSnapshot, changedSnapshot)
+    }
+
+    private fun tab(
+        id: String,
+        vararg entries: BackStackEntry,
+    ): TabState = TabState(TabId(id), navigation(*entries))
+
+    private fun navigation(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> throw AssertionError(result.problems)
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        BackStackEntry(EntryId(id), route)
+
+    private fun leafSnapshot(
+        entryId: String,
+        routeType: String,
+    ): NavStateSnapshot = NavStateSnapshot(
+        version = NavStateSnapshot.CURRENT_VERSION,
+        entries = listOf(snapshotEntry(entryId, routeType)),
+    )
+
+    private fun snapshotEntry(
+        id: String,
+        routeType: String,
+        vararg arguments: Pair<String, String>,
+    ): NavStateSnapshot.Entry = NavStateSnapshot.Entry(
+        id = id,
+        routeType = routeType,
+        arguments = mapOf(*arguments),
+    )
+
+    private fun snapshotTab(
+        id: String,
+        vararg entries: NavStateSnapshot.Entry,
+    ): TabNavigationStateSnapshot.Tab = TabNavigationStateSnapshot.Tab(
+        id = id,
+        history = NavStateSnapshot(
+            version = NavStateSnapshot.CURRENT_VERSION,
+            entries = entries.toList(),
+        ),
+    )
+
+    private fun tabProblem(
+        tabIndex: Int,
+        tabId: String,
+        problem: SnapshotProblem,
+    ): TabNavigationSnapshotProblem = TabNavigationSnapshotProblem.HistoryProblem(
+        tabIndex = tabIndex,
+        tabId = tabId,
+        problem = problem,
+    )
+
+    private fun encodeProblem(
+        tabIndex: Int,
+        tabId: String,
+        entryIndex: Int,
+        entryId: String,
+        slug: String,
+    ): TabNavigationSnapshotProblem = tabProblem(
+        tabIndex = tabIndex,
+        tabId = tabId,
+        problem = SnapshotProblem.RouteEncodeFailed(
+            index = entryIndex,
+            entryId = EntryId(entryId),
+            error = RouteCodecError(
+                code = "unsupported_consumer_route",
+                message = "Unsupported consumer route: $slug",
+            ),
+        ),
+    )
+
+    private fun decodeProblem(
+        tabIndex: Int,
+        tabId: String,
+        entryIndex: Int,
+        entryId: String,
+        routeType: String,
+    ): TabNavigationSnapshotProblem = tabProblem(
+        tabIndex = tabIndex,
+        tabId = tabId,
+        problem = SnapshotProblem.RouteDecodeFailed(
+            index = entryIndex,
+            entryId = entryId,
+            routeType = routeType,
+            error = RouteCodecError(
+                code = "unknown_consumer_route",
+                message = "Unknown consumer route type: $routeType",
+            ),
+        ),
+    )
+
+    private fun snapshotSuccess(
+        result: TabNavigationSnapshotResult<TabNavigationStateSnapshot>,
+    ): TabNavigationStateSnapshot = when (result) {
+        is TabNavigationSnapshotResult.Success -> result.value
+        is TabNavigationSnapshotResult.Failure -> throw AssertionError(result.problems)
+    }
+
+    private fun restoreSuccess(
+        result: TabNavigationSnapshotResult<TabNavigationState>,
+    ): TabNavigationState = when (result) {
+        is TabNavigationSnapshotResult.Success -> result.value
+        is TabNavigationSnapshotResult.Failure -> throw AssertionError(result.problems)
+    }
+
+    private fun snapshotFailure(
+        result: TabNavigationSnapshotResult<*>,
+    ): List<TabNavigationSnapshotProblem> =
+        when (result) {
+            is TabNavigationSnapshotResult.Success ->
+                throw AssertionError("Expected failure, got ${result.value}")
+            is TabNavigationSnapshotResult.Failure -> result.problems
+        }
+
+    private class RecordingCodec : RouteCodec {
+        var decodeCalls: Int = 0
+
+        override fun encode(route: Route): RouteEncodeResult {
+            throw AssertionError("encode must not be called")
+        }
+
+        override fun decode(
+            type: String,
+            arguments: Map<String, String>,
+        ): RouteDecodeResult {
+            decodeCalls += 1
+            return RouteDecodeResult.Success(Accounts)
+        }
+    }
+
+    private data class CorruptGraphCase(
+        val snapshot: TabNavigationStateSnapshot,
+        val expected: TabNavigationStateProblem,
+    )
+
+    private data class ConsumerRoute(val slug: String) : ContentRoute
+
+    private data class UnsupportedConsumerRoute(val slug: String) : ContentRoute
+
+    private object ConsumerCodec : RouteCodec {
+        override fun encode(route: Route): RouteEncodeResult = when (route) {
+            is ConsumerRoute -> RouteEncodeResult.Success(
+                EncodedRoute(
+                    type = "consumer/v1",
+                    arguments = mapOf("slug" to route.slug),
+                ),
+            )
+            is UnsupportedConsumerRoute -> RouteEncodeResult.Failure(
+                RouteCodecError(
+                    code = "unsupported_consumer_route",
+                    message = "Unsupported consumer route: ${route.slug}",
+                ),
+            )
+            else -> RouteEncodeResult.Failure(
+                RouteCodecError(
+                    code = "unsupported_consumer_route",
+                    message = "Unsupported consumer route: $route",
+                ),
+            )
+        }
+
+        override fun decode(
+            type: String,
+            arguments: Map<String, String>,
+        ): RouteDecodeResult = if (
+            type == "consumer/v1" && arguments.keys == setOf("slug")
+        ) {
+            RouteDecodeResult.Success(ConsumerRoute(arguments.getValue("slug")))
+        } else {
+            RouteDecodeResult.Failure(
+                RouteCodecError(
+                    code = "unknown_consumer_route",
+                    message = "Unknown consumer route type: $type",
+                ),
+            )
+        }
+    }
+
+    private object ThrowingEncodeCodec : RouteCodec {
+        override fun encode(route: Route): RouteEncodeResult =
+            throw IllegalStateException("encode boom")
+
+        override fun decode(
+            type: String,
+            arguments: Map<String, String>,
+        ): RouteDecodeResult = throw AssertionError("decode is not used")
+    }
+
+    private object ThrowingDecodeCodec : RouteCodec {
+        override fun encode(route: Route): RouteEncodeResult =
+            throw AssertionError("encode is not used")
+
+        override fun decode(
+            type: String,
+            arguments: Map<String, String>,
+        ): RouteDecodeResult = throw IllegalStateException("decode boom")
+    }
+}

--- a/app/src/test/java/com/shmakov/udf/navigation/TabNavigationSnapshotJavaApiTest.java
+++ b/app/src/test/java/com/shmakov/udf/navigation/TabNavigationSnapshotJavaApiTest.java
@@ -1,0 +1,131 @@
+package com.shmakov.udf.navigation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public final class TabNavigationSnapshotJavaApiTest {
+
+    @Test
+    public void snapshotAndStaticRestoreNeedNoCompanionSyntax() {
+        TabId accountsId = new TabId("accounts");
+        TabState accounts = new TabState(
+                accountsId,
+                validNavigation(new BackStackEntry(new EntryId("accounts-root"), Accounts.INSTANCE))
+        );
+        TabState cards = new TabState(
+                new TabId("cards"),
+                validNavigation(new BackStackEntry(new EntryId("cards-root"), Cards.INSTANCE))
+        );
+        TabNavigationState state = TabNavigationState.create(
+                accountsId,
+                Arrays.asList(accounts, cards)
+        );
+
+        TabNavigationSnapshotResult<TabNavigationStateSnapshot> encoded =
+                state.toSnapshot(DemoRouteCodec.INSTANCE);
+        assertTrue(encoded instanceof TabNavigationSnapshotResult.Success);
+        TabNavigationStateSnapshot snapshot =
+                ((TabNavigationSnapshotResult.Success<TabNavigationStateSnapshot>) encoded)
+                        .getValue();
+
+        TabNavigationSnapshotResult<TabNavigationState> decoded =
+                TabNavigationState.restore(snapshot, DemoRouteCodec.INSTANCE);
+
+        assertEquals(TabNavigationStateSnapshot.CURRENT_VERSION, snapshot.getVersion());
+        assertTrue(decoded instanceof TabNavigationSnapshotResult.Success);
+        assertEquals(
+                state,
+                ((TabNavigationSnapshotResult.Success<TabNavigationState>) decoded).getValue()
+        );
+    }
+
+    @Test
+    public void nullJavaCodecResultsKeepTabAndEntryContext() {
+        TabId accountsId = new TabId("accounts");
+        BackStackEntry root = new BackStackEntry(new EntryId("accounts-root"), Accounts.INSTANCE);
+        TabNavigationState state = TabNavigationState.create(
+                accountsId,
+                Collections.singletonList(new TabState(accountsId, validNavigation(root)))
+        );
+        RouteCodec nullCodec = new RouteCodec() {
+            @Override
+            public RouteEncodeResult encode(Route route) {
+                return null;
+            }
+
+            @Override
+            public RouteDecodeResult decode(String type, java.util.Map<String, String> arguments) {
+                return null;
+            }
+        };
+
+        TabNavigationSnapshotResult<TabNavigationStateSnapshot> encoded =
+                state.toSnapshot(nullCodec);
+        assertTrue(encoded instanceof TabNavigationSnapshotResult.Failure);
+        assertEquals(
+                Collections.singletonList(
+                        new TabNavigationSnapshotProblem.HistoryProblem(
+                                0,
+                                "accounts",
+                                new SnapshotProblem.RouteEncodeFailed(
+                                        0,
+                                        root.getId(),
+                                        nullCodecError()
+                                )
+                        )
+                ),
+                ((TabNavigationSnapshotResult.Failure) encoded).getProblems()
+        );
+
+        NavStateSnapshot leaf = new NavStateSnapshot(
+                NavStateSnapshot.CURRENT_VERSION,
+                Collections.singletonList(
+                        new NavStateSnapshot.Entry(
+                                "accounts-root",
+                                "accounts/v1",
+                                Collections.emptyMap()
+                        )
+                )
+        );
+        TabNavigationStateSnapshot snapshot = new TabNavigationStateSnapshot(
+                TabNavigationStateSnapshot.CURRENT_VERSION,
+                "accounts",
+                Collections.singletonList(
+                        new TabNavigationStateSnapshot.Tab("accounts", leaf)
+                )
+        );
+        TabNavigationSnapshotResult<TabNavigationState> decoded =
+                TabNavigationState.restore(snapshot, nullCodec);
+
+        assertTrue(decoded instanceof TabNavigationSnapshotResult.Failure);
+        assertEquals(
+                Collections.singletonList(
+                        new TabNavigationSnapshotProblem.HistoryProblem(
+                                0,
+                                "accounts",
+                                new SnapshotProblem.RouteDecodeFailed(
+                                        0,
+                                        "accounts-root",
+                                        "accounts/v1",
+                                        nullCodecError()
+                                )
+                        )
+                ),
+                ((TabNavigationSnapshotResult.Failure) decoded).getProblems()
+        );
+    }
+
+    private static NavState validNavigation(BackStackEntry root) {
+        NavStateCreationResult created = NavState.fromEntries(Collections.singletonList(root));
+        assertTrue(created instanceof NavStateCreationResult.Valid);
+        return ((NavStateCreationResult.Valid) created).getState();
+    }
+
+    private static RouteCodecError nullCodecError() {
+        return new RouteCodecError("codec_exception", "Route codec returned null.");
+    }
+}

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -30,9 +30,11 @@
 
 ## Текущая модель
 
-`AppState` содержит `NavState`, а `NavState` — непустой список `BackStackEntry(id, route)`. Route описывает semantic target и arguments, а entry ID — конкретное появление route в истории. Модель проверяет content-root, однозначный content/modal kind и уникальность IDs.
+`AppState` пока содержит один `NavState`, а `NavState` — непустой список `BackStackEntry(id, route)`. Route описывает semantic target и arguments, а entry ID — конкретное появление route в истории. Модель проверяет content-root, однозначный content/modal kind и уникальность IDs.
 
 Открытые `ContentRoute` и `ModalRoute` позволяют приложению объявлять собственные routes. Versioned primitive snapshot отделён от route objects; приложение подключает их через `RouteCodec`, а восстановление всегда повторно использует validation `NavState`.
+
+`TabNavigationState` — следующий pure composition layer: ordered list хранит стабильные `TabId`, отдельный non-empty `NavState` каждого tab и выбранный tab, а validator обеспечивает graph-wide уникальность `EntryId`. `TabReducer` разделяет container actions и exact leaf navigation, оставляет inactive histories теми же instances и поддерживает атомарные `OpenTab`/`ReplaceGraph`. `TabNavigationStateSnapshot` композиционно сохраняет selected tab, порядок tabs и каждый leaf `NavStateSnapshot` через один application `RouteCodec`; nested problems получают tab index/ID, а итоговый graph повторно проходит `TabNavigationState.fromTabs`. Graph использует отдельные `TabNavigationSnapshotResult`/`TabNavigationSnapshotProblem`, поэтому composition-specific diagnostics не расширяют sealed leaf `SnapshotProblem`. Outer, leaf и route payload versions независимы. Snapshot не содержит transition metadata и сам по себе ещё не является Android lifecycle evidence.
 
 Navigation input представлен закрытым набором typed `NavAction`, а `NavReducer.reduce(state, action)` является чистой Kotlin-функцией. Результат — `NavReduction.Changed(state, transition)` либо `NavReduction.Unchanged(state, reason)`. Action factories материализуют identity новых entries до reduction, поэтому reducer не генерирует случайные значения.
 
@@ -293,7 +295,7 @@ Route, entry identity, validated `NavState`, primitive snapshot, `SavedStateHand
 
 - Должна ли каноническая навигация остаться линейной историей или стать явным деревом?
 - Как превратить внутреннее exact-intent matching в простой application-defined animation policy API?
-- Как обобщить stateful tab graph с независимыми histories, не усложнив линейный базовый API?
+- Как встроить уже выделенный stateful tab graph в store/renderer и per-entry saveable state, не усложнив линейный базовый API?
 - Как predictive Back интегрируется с reducer-owned navigation state?
 - Может ли Navigation Compose помочь с платформенной интеграцией, не становясь владельцем канонической истории?
 

--- a/docs/evidence/issue-46/README.md
+++ b/docs/evidence/issue-46/README.md
@@ -1,0 +1,67 @@
+# Issue #46 — versioned snapshot of the complete tab graph
+
+## Scope
+
+This pure Kotlin slice adds a primitive snapshot for `TabNavigationState`: selected tab, exact
+ordered tab IDs, every independent `NavStateSnapshot`, and every exact entry ID. It reuses the
+application `RouteCodec`, leaf validation, and whole-graph validation. A dedicated
+`TabNavigationSnapshotResult`/`TabNavigationSnapshotProblem` keeps graph-only diagnostics out of
+the sealed leaf snapshot API.
+
+It does not add a transport envelope, `SavedStateHandle`, store ownership, Compose integration, or
+device behavior. The successful round trip below is therefore not Activity recreation or Android
+process-death evidence.
+
+## TDD evidence
+
+1. Kotlin wire-shape/round-trip/corruption contracts and a Java API smoke test were added first.
+2. The observed RED run failed at test compilation because `TabNavigationStateSnapshot`,
+   `toSnapshot`, static `restore`, `TabHistoryProblem`, and `InvalidTabNavigationState` did not
+   exist.
+3. The minimal production API made the first five contracts pass.
+4. The matrix was expanded to 16 focused contracts covering application codecs, deterministic
+   multi-failure ordering, nested leaf failures, graph corruption, phase precedence, deep
+   defensive copies, transition exclusion, exceptions, and Java null returns.
+5. External-consumer review found that adding tab variants to sealed leaf `SnapshotProblem` would
+   break exhaustive leaf consumers. Tests were changed first and failed because the dedicated tab
+   result/problem boundary did not exist; the refined API then restored GREEN.
+6. A brittle private-field reflection assertion was removed after test review; exact wire shape and
+   durable-state equality retain the meaningful contract.
+7. The expanded focused suite and the forced full project gate passed.
+
+## Verified contracts
+
+- exact selected tab, tab order/IDs, leaf order/routes/arguments, and every `EntryId` round trip;
+- one application-owned codec works for arbitrary routes across multiple arbitrary tabs;
+- outer, leaf, and route payload versions are independent, with outer-version fail-fast;
+- encode and restore are all-or-nothing and never generate replacement IDs or partial graphs;
+- failures aggregate in deterministic tab-major/entry-major order;
+- nested codec/version/state failures retain raw tab index/ID and complete leaf context;
+- child restoration failures precede and suppress whole-graph validation;
+- empty/blank/duplicate/missing/cross-tab corruption reuses existing typed validators;
+- caller-owned tab, entry, and argument collections are deeply copied and runtime-unmodifiable;
+- independently built equal snapshots compare structurally, while tab order remains significant;
+- the snapshot surface contains no transition, animation, presentation, revision, label, or icon;
+- Kotlin and Java use `state.toSnapshot(codec)` and static
+  `TabNavigationState.restore(snapshot, codec)` without companion syntax;
+- Java codec `null` results remain typed beneath tab and entry context.
+
+## Final verification
+
+```text
+Focused tab snapshot API: 16/16
+
+./gradlew testDebugUnitTest --rerun-tasks lintDebug assembleDebug assembleDebugAndroidTest
+BUILD SUCCESSFUL
+
+JVM: 237 tests / 26 suites
+Failures: 0
+Errors: 0
+Skipped: 0
+```
+
+Architecture, test, and external-consumer re-reviews reported no remaining P0, P1, or P2
+findings after the result/problem boundary refinement.
+
+No emulator or screenshot is attached because this slice has no Android integration or visible UI
+behavior. Whole-graph lifecycle and device evidence belongs to the following children of #26.


### PR DESCRIPTION
## Summary

- add a primitive versioned snapshot for the complete ordered tab graph
- preserve selected tab, every tab/history/route argument, and exact tab/entry identities
- reuse one application `RouteCodec` while keeping contextual tab → leaf diagnostics
- keep graph-only result/problems separate from sealed leaf snapshot API
- restore all leaf histories before one whole-graph validation; never return partial state
- add deep defensive copies, Kotlin contracts, Java API/null-safety smoke tests, and durable docs

## TDD

- initial RED failed at compilation because the graph snapshot/API/problems did not exist
- external review then identified leaf sealed-family pollution; revised tests failed before adding dedicated `TabNavigationSnapshotResult/Problem`
- final focused snapshot suite: 16/16

## Verification

```
./gradlew testDebugUnitTest --rerun-tasks lintDebug assembleDebug assembleDebugAndroidTest
BUILD SUCCESSFUL

JVM: 237 tests / 26 suites
Failures: 0
Errors: 0
Skipped: 0
```

Architecture, test, and external-consumer re-reviews: no remaining P0/P1/P2.

No emulator was used because this is a pure Kotlin, non-UI slice. It does not claim Activity recreation or process-death integration; that remains a later child of #26.

Closes #46