### PR TITLE
Add one-key SavedStateHandle storage for tab navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Navigation core уже содержит валидируемую entry model, с
 - непустой stack с content-root и уникальными entry IDs;
 - versioned snapshot и расширяемый route codec без Android/Compose dependencies;
 - immutable ordered tab graph, typed container/leaf actions и versioned snapshot всего graph;
+- one-key `SavedStateHandle` storage всего tab graph с отдельным versioned envelope;
 - typed push, pop, branch replacement, exact-ID modal dismiss и полную замену history;
 - чистый reducer с явными `Changed`/`Unchanged` outcomes;
 - transient transition intent, который не попадает в `NavState` или snapshot;
@@ -118,7 +119,9 @@ when (val snapshotResult = graph.toSnapshot(routeCodec)) {
 }
 ```
 
-Primitive `TabNavigationStateSnapshot` сохраняет selected tab, точный порядок tab-ов, все histories и exact IDs. `TabNavigationSnapshotResult` и `TabNavigationSnapshotProblem` отделены от leaf-result обычного `NavState`, поэтому новые graph diagnostics не добавляют невозможные ветви в leaf API. Он не содержит labels/icons, transition intent, animation, revision или Compose state. Это DTO, а не готовый `Bundle`/JSON transport: lifecycle/store интеграция всего graph будет отдельным этапом и только она сможет доказать recreation/process restoration.
+Primitive `TabNavigationStateSnapshot` сохраняет selected tab, точный порядок tab-ов, все histories и exact IDs. `TabNavigationSnapshotResult` и `TabNavigationSnapshotProblem` отделены от leaf-result обычного `NavState`, поэтому новые graph diagnostics не добавляют невозможные ветви в leaf API. Snapshot не содержит labels/icons, transition intent, animation, revision или Compose state.
+
+Внутренний `SavedStateHandleTabNavigationStorage` оборачивает DTO в один defensive `ArrayList<String>` под отдельным key. Outer envelope хранит selected tab и ordered tab segments; каждый segment — полный length-prefixed payload существующего leaf-envelope, поэтому версии graph transport, graph snapshot, leaf transport, leaf snapshot и route payload не смешиваются. Storage принимает application-owned `RouteCodec`, возвращает typed `Missing`/`Restored`/`Rejected`, очищает только свой stale key и никогда не выбирает fallback. Это ещё не observable state owner и не доказательство Activity recreation/process death — owner/frame policy остаётся следующим этапом.
 
 ## Чистая layout projection
 
@@ -359,6 +362,8 @@ setContent {
 
 `SavedNavigationStateStore` хранит под одним private key ровно одно атомарное значение `ArrayList<String>`. Versioned envelope содержит magic, версии envelope и snapshot, counts, точные entry IDs, route types и отсортированные пары route arguments. При чтении envelope сначала декодируется, затем проходит обычные `DemoRouteCodec` и `NavState.restore`, поэтому empty/non-content root, duplicate IDs, неизвестный route и устаревшая версия не обходят инварианты модели.
 
+Параллельный internal tab-storage использует другой key и magic, не меняя linear payload. Он сохраняет весь `TabNavigationState` одним присваиванием и восстанавливает graph только после outer decode, всех leaf decodes и полного `TabNavigationState.restore`. Повреждение любой history отклоняет весь graph; partial restoration отдельных tab-ов отсутствует.
+
 `AppViewModel` восстанавливает history до создания store. Отсутствующий payload, повреждённый envelope и несовместимый snapshot приводят к полной fallback-history без частичного восстановления; stale value удаляется, а выбранная fallback-history немедленно записывается обратно как canonical payload. Валидный payload восстанавливает те же routes, arguments и entry IDs. И свежий, и восстановленный owner начинают с `AppStateFrame(revision = 0, intent = null)`: process-local revision, transition intent, retained modal state и animation progress не сохраняются.
 
 `dispatch` всегда применяет action к последнему committed state под одной короткой критической секцией. Для `Changed` store вызывает persistence следующего `NavState` до публикации единого frame и увеличения revision; typed save failure не отменяет валидный in-memory transition, но не оставляет старый payload каноническим. `Unchanged` не пишет в `SavedStateHandle` и сохраняет тот же frame instance. Transition — process-local metadata текущего frame, sticky до следующего `Changed`; он не является pending event и не восстанавливается из snapshot. Поэтому initial/restored render, renderer/composition recreation, layout-only reprojection и пропуск промежуточного frame не переигрывают старый push, pop или dismiss.
@@ -369,6 +374,7 @@ Pure JVM contracts проверяют wire format, validation/fallback, save-bef
 
 - [`AppState.kt`](app/src/main/java/com/shmakov/udf/AppState.kt), [`AppStore.kt`](app/src/main/java/com/shmakov/udf/AppStore.kt) и [`AppViewModel.kt`](app/src/main/java/com/shmakov/udf/AppViewModel.kt) — immutable application state, persist-before-frame store и Activity-scoped lifecycle owner.
 - [`NavigationSnapshotEnvelope.kt`](app/src/main/java/com/shmakov/udf/NavigationSnapshotEnvelope.kt) и [`SavedNavigationStateStore.kt`](app/src/main/java/com/shmakov/udf/SavedNavigationStateStore.kt) — one-key Bundle-safe wire format и typed `SavedStateHandle` restoration boundary.
+- [`TabNavigationSnapshotEnvelope.kt`](app/src/main/java/com/shmakov/udf/TabNavigationSnapshotEnvelope.kt) и [`SavedStateHandleTabNavigationStorage.kt`](app/src/main/java/com/shmakov/udf/SavedStateHandleTabNavigationStorage.kt) — отдельный one-key graph envelope и storage adapter без fallback/owner policy.
 - [`UdfApp.kt`](app/src/main/java/com/shmakov/udf/UdfApp.kt) — только application initialization и logging; navigation state там не хранится.
 - [`deeplink/`](app/src/main/java/com/shmakov/udf/deeplink) — framework-free URI parsing, demo normalization и validated hydration полной history.
 - [`navigation/`](app/src/main/java/com/shmakov/udf/navigation) — routes, back-stack entries, валидируемый navigation state, actions/reducer, snapshot/codec и screen abstractions.

--- a/app/src/main/java/com/shmakov/udf/SavedStateHandleTabNavigationStorage.kt
+++ b/app/src/main/java/com/shmakov/udf/SavedStateHandleTabNavigationStorage.kt
@@ -1,0 +1,250 @@
+package com.shmakov.udf
+
+import androidx.lifecycle.SavedStateHandle
+import com.shmakov.udf.navigation.RouteCodec
+import com.shmakov.udf.navigation.TabNavigationSnapshotProblem
+import com.shmakov.udf.navigation.TabNavigationSnapshotResult
+import com.shmakov.udf.navigation.TabNavigationState
+import java.util.Collections
+
+/** A complete tab graph snapshot could not be prepared for Android saved state. */
+internal sealed class TabNavigationSaveProblem {
+    data class Snapshot(
+        val problem: TabNavigationSnapshotProblem,
+    ) : TabNavigationSaveProblem()
+
+    data class SavedStateAccess(
+        val code: String,
+        val message: String,
+    ) : TabNavigationSaveProblem()
+
+    data class Unexpected(
+        val code: String,
+        val message: String,
+    ) : TabNavigationSaveProblem()
+}
+
+/** Result of atomically replacing the one saved tab-navigation payload. */
+internal sealed class TabNavigationSaveResult {
+    object Saved : TabNavigationSaveResult()
+
+    class Failed(
+        problems: List<TabNavigationSaveProblem>,
+    ) : TabNavigationSaveResult() {
+        val problems: List<TabNavigationSaveProblem> = immutableTabStorageListCopy(problems)
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is Failed && problems == other.problems
+
+        override fun hashCode(): Int = problems.hashCode()
+
+        override fun toString(): String = "Failed(problems=$problems)"
+    }
+}
+
+/** A saved tab-navigation payload was present but could not be restored safely. */
+internal sealed class TabNavigationRestoreProblem {
+    data class InvalidEnvelope(
+        val problem: TabNavigationSnapshotEnvelopeProblem,
+    ) : TabNavigationRestoreProblem()
+
+    data class InvalidSnapshot(
+        val problem: TabNavigationSnapshotProblem,
+    ) : TabNavigationRestoreProblem()
+
+    data class SavedStateAccess(
+        val code: String,
+        val message: String,
+    ) : TabNavigationRestoreProblem()
+
+    data class Unexpected(
+        val code: String,
+        val message: String,
+    ) : TabNavigationRestoreProblem()
+}
+
+/** Result of reading and validating the one saved tab-navigation payload. */
+internal sealed class TabNavigationRestoreResult {
+    object Missing : TabNavigationRestoreResult()
+
+    data class Restored(
+        val state: TabNavigationState,
+    ) : TabNavigationRestoreResult()
+
+    class Rejected(
+        problems: List<TabNavigationRestoreProblem>,
+    ) : TabNavigationRestoreResult() {
+        val problems: List<TabNavigationRestoreProblem> =
+            immutableTabStorageListCopy(problems)
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is Rejected && problems == other.problems
+
+        override fun hashCode(): Int = problems.hashCode()
+
+        override fun toString(): String = "Rejected(problems=$problems)"
+    }
+}
+
+/**
+ * One-key [SavedStateHandle] storage adapter for a complete [TabNavigationState].
+ *
+ * This class does not own observable state, choose a fallback graph, dispatch actions, or persist
+ * transition metadata. The same application-owned [routeCodec] is used for save and restore.
+ */
+internal class SavedStateHandleTabNavigationStorage(
+    private val savedStateHandle: SavedStateHandle,
+    private val routeCodec: RouteCodec,
+) {
+    fun save(state: TabNavigationState): TabNavigationSaveResult {
+        val snapshot = try {
+            state.toSnapshot(routeCodec)
+        } catch (exception: Exception) {
+            clearStalePayload()
+            return saveUnexpectedFailure(SNAPSHOT_EXCEPTION_CODE, exception)
+        }
+
+        val payload = when (snapshot) {
+            is TabNavigationSnapshotResult.Success -> try {
+                TabNavigationSnapshotEnvelopeCodec.encode(snapshot.value)
+            } catch (exception: Exception) {
+                clearStalePayload()
+                return saveUnexpectedFailure(ENVELOPE_ENCODE_EXCEPTION_CODE, exception)
+            }
+            is TabNavigationSnapshotResult.Failure -> {
+                clearStalePayload()
+                return TabNavigationSaveResult.Failed(
+                    snapshot.problems.map(TabNavigationSaveProblem::Snapshot),
+                )
+            }
+        }
+
+        return try {
+            savedStateHandle[TAB_NAVIGATION_STATE_KEY] = ArrayList(payload)
+            TabNavigationSaveResult.Saved
+        } catch (exception: Exception) {
+            clearStalePayload()
+            saveAccessFailure(SAVED_STATE_WRITE_EXCEPTION_CODE, exception)
+        }
+    }
+
+    fun restore(): TabNavigationRestoreResult {
+        val hasPayload = try {
+            savedStateHandle.contains(TAB_NAVIGATION_STATE_KEY)
+        } catch (exception: Exception) {
+            clearStalePayload()
+            return restoreAccessFailure(SAVED_STATE_READ_EXCEPTION_CODE, exception)
+        }
+        if (!hasPayload) return TabNavigationRestoreResult.Missing
+
+        val rawPayload = try {
+            savedStateHandle.get<Any?>(TAB_NAVIGATION_STATE_KEY)
+        } catch (exception: Exception) {
+            clearStalePayload()
+            return restoreAccessFailure(SAVED_STATE_READ_EXCEPTION_CODE, exception)
+        }
+        val decoded = try {
+            TabNavigationSnapshotEnvelopeCodec.decode(rawPayload)
+        } catch (exception: Exception) {
+            clearStalePayload()
+            return restoreUnexpectedFailure(ENVELOPE_DECODE_EXCEPTION_CODE, exception)
+        }
+        val snapshot = when (decoded) {
+            is TabNavigationSnapshotEnvelopeDecodeResult.Decoded -> decoded.snapshot
+            is TabNavigationSnapshotEnvelopeDecodeResult.Rejected -> {
+                clearStalePayload()
+                return TabNavigationRestoreResult.Rejected(
+                    decoded.problems.map(TabNavigationRestoreProblem::InvalidEnvelope),
+                )
+            }
+        }
+
+        val restored = try {
+            TabNavigationState.restore(snapshot, routeCodec)
+        } catch (exception: Exception) {
+            clearStalePayload()
+            return restoreUnexpectedFailure(SNAPSHOT_RESTORE_EXCEPTION_CODE, exception)
+        }
+        return when (restored) {
+            is TabNavigationSnapshotResult.Success ->
+                TabNavigationRestoreResult.Restored(restored.value)
+            is TabNavigationSnapshotResult.Failure -> {
+                clearStalePayload()
+                TabNavigationRestoreResult.Rejected(
+                    restored.problems.map(TabNavigationRestoreProblem::InvalidSnapshot),
+                )
+            }
+        }
+    }
+
+    private fun clearStalePayload() {
+        try {
+            savedStateHandle.remove<Any?>(TAB_NAVIGATION_STATE_KEY)
+        } catch (_: Exception) {
+            // The original typed failure remains the useful result; cleanup is best effort.
+        }
+    }
+
+    private fun saveAccessFailure(
+        code: String,
+        exception: Exception,
+    ): TabNavigationSaveResult = TabNavigationSaveResult.Failed(
+        listOf(
+            TabNavigationSaveProblem.SavedStateAccess(
+                code = code,
+                message = exception.persistenceMessage(),
+            ),
+        ),
+    )
+
+    private fun saveUnexpectedFailure(
+        code: String,
+        exception: Exception,
+    ): TabNavigationSaveResult = TabNavigationSaveResult.Failed(
+        listOf(
+            TabNavigationSaveProblem.Unexpected(
+                code = code,
+                message = exception.persistenceMessage(),
+            ),
+        ),
+    )
+
+    private fun restoreAccessFailure(
+        code: String,
+        exception: Exception,
+    ): TabNavigationRestoreResult = TabNavigationRestoreResult.Rejected(
+        listOf(
+            TabNavigationRestoreProblem.SavedStateAccess(
+                code = code,
+                message = exception.persistenceMessage(),
+            ),
+        ),
+    )
+
+    private fun restoreUnexpectedFailure(
+        code: String,
+        exception: Exception,
+    ): TabNavigationRestoreResult = TabNavigationRestoreResult.Rejected(
+        listOf(
+            TabNavigationRestoreProblem.Unexpected(
+                code = code,
+                message = exception.persistenceMessage(),
+            ),
+        ),
+    )
+
+    private fun Exception.persistenceMessage(): String = message ?: javaClass.name
+
+    private companion object {
+        const val TAB_NAVIGATION_STATE_KEY = "com.shmakov.udf.saved-tab-navigation-state"
+        const val SNAPSHOT_EXCEPTION_CODE = "snapshot_exception"
+        const val ENVELOPE_ENCODE_EXCEPTION_CODE = "envelope_encode_exception"
+        const val ENVELOPE_DECODE_EXCEPTION_CODE = "envelope_decode_exception"
+        const val SNAPSHOT_RESTORE_EXCEPTION_CODE = "snapshot_restore_exception"
+        const val SAVED_STATE_READ_EXCEPTION_CODE = "saved_state_read_exception"
+        const val SAVED_STATE_WRITE_EXCEPTION_CODE = "saved_state_write_exception"
+    }
+}
+
+private fun <T> immutableTabStorageListCopy(source: Collection<T>): List<T> =
+    Collections.unmodifiableList(ArrayList(source))

--- a/app/src/main/java/com/shmakov/udf/TabNavigationSnapshotEnvelope.kt
+++ b/app/src/main/java/com/shmakov/udf/TabNavigationSnapshotEnvelope.kt
@@ -1,0 +1,219 @@
+package com.shmakov.udf
+
+import com.shmakov.udf.navigation.TabNavigationStateSnapshot
+import java.util.Collections
+
+/** A malformed or unsupported primitive tab-navigation persistence envelope. */
+internal sealed class TabNavigationSnapshotEnvelopeProblem {
+    data class InvalidPayload(
+        val code: String,
+        val message: String,
+    ) : TabNavigationSnapshotEnvelopeProblem()
+
+    data class UnsupportedEnvelopeVersion(
+        val version: Int,
+    ) : TabNavigationSnapshotEnvelopeProblem()
+
+    data class HistoryEnvelopeProblem(
+        val tabIndex: Int,
+        val tabId: String,
+        val problem: NavigationSnapshotEnvelopeProblem,
+    ) : TabNavigationSnapshotEnvelopeProblem()
+}
+
+/** Result of decoding the one-value Android representation of a tab graph snapshot. */
+internal sealed class TabNavigationSnapshotEnvelopeDecodeResult {
+    data class Decoded(
+        val snapshot: TabNavigationStateSnapshot,
+    ) : TabNavigationSnapshotEnvelopeDecodeResult()
+
+    class Rejected(
+        problems: List<TabNavigationSnapshotEnvelopeProblem>,
+    ) : TabNavigationSnapshotEnvelopeDecodeResult() {
+        val problems: List<TabNavigationSnapshotEnvelopeProblem> =
+            immutableTabEnvelopeListCopy(problems)
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is Rejected && problems == other.problems
+
+        override fun hashCode(): Int = problems.hashCode()
+
+        override fun toString(): String = "Rejected(problems=$problems)"
+    }
+}
+
+/**
+ * Converts a complete [TabNavigationStateSnapshot] to one flat Bundle-safe primitive value.
+ *
+ * Every history is a length-prefixed complete [NavigationSnapshotEnvelopeCodec] payload. Outer,
+ * leaf-envelope, graph-snapshot, leaf-snapshot, and route payload versions can therefore evolve
+ * independently without duplicating the strict leaf parser.
+ */
+internal object TabNavigationSnapshotEnvelopeCodec {
+    fun encode(snapshot: TabNavigationStateSnapshot): ArrayList<String> =
+        arrayListOf<String>().apply {
+            add(MAGIC)
+            add(CURRENT_ENVELOPE_VERSION.toString())
+            add(snapshot.version.toString())
+            add(snapshot.selectedTabId)
+            add(snapshot.tabs.size.toString())
+
+            snapshot.tabs.forEach { tab ->
+                val historyPayload = NavigationSnapshotEnvelopeCodec.encode(tab.history)
+                add(tab.id)
+                add(historyPayload.size.toString())
+                addAll(historyPayload)
+            }
+        }
+
+    fun decode(value: Any?): TabNavigationSnapshotEnvelopeDecodeResult {
+        val rawTokens = value as? ArrayList<*>
+            ?: return invalid(
+                code = WRONG_TYPE_CODE,
+                message = "Tab navigation payload must be an ArrayList of strings.",
+            )
+        val tokens = try {
+            ArrayList<String>(rawTokens.size).apply {
+                rawTokens.forEach { token ->
+                    add(
+                        token as? String
+                            ?: return invalid(
+                                code = WRONG_TYPE_CODE,
+                                message = "Every tab navigation payload token must be a string.",
+                            ),
+                    )
+                }
+            }
+        } catch (exception: Exception) {
+            return invalid(
+                code = INVALID_PAYLOAD_CODE,
+                message = exception.message ?: "Tab navigation payload could not be read.",
+            )
+        }
+        var cursor = 0
+
+        fun nextToken(): String? = tokens.getOrNull(cursor)?.also { cursor += 1 }
+        fun truncated(): TabNavigationSnapshotEnvelopeDecodeResult = invalid(
+            code = TRUNCATED_CODE,
+            message = "Tab navigation payload ended before its declared data was complete.",
+        )
+
+        val magic = nextToken() ?: return truncated()
+        if (magic != MAGIC) {
+            return invalid(
+                code = INVALID_MAGIC_CODE,
+                message = "Tab navigation payload has an unknown magic header.",
+            )
+        }
+
+        val envelopeVersionToken = nextToken() ?: return truncated()
+        val envelopeVersion = envelopeVersionToken.toIntOrNull()
+            ?: return invalid(
+                code = INVALID_ENVELOPE_VERSION_CODE,
+                message = "Tab navigation envelope version is not an integer.",
+            )
+        if (envelopeVersion != CURRENT_ENVELOPE_VERSION) {
+            return TabNavigationSnapshotEnvelopeDecodeResult.Rejected(
+                listOf(
+                    TabNavigationSnapshotEnvelopeProblem.UnsupportedEnvelopeVersion(
+                        version = envelopeVersion,
+                    ),
+                ),
+            )
+        }
+
+        val snapshotVersionToken = nextToken() ?: return truncated()
+        val snapshotVersion = snapshotVersionToken.toIntOrNull()
+            ?: return invalid(
+                code = INVALID_SNAPSHOT_VERSION_CODE,
+                message = "Tab navigation snapshot version is not an integer.",
+            )
+        val selectedTabId = nextToken() ?: return truncated()
+        val tabCountToken = nextToken() ?: return truncated()
+        val tabCount = tabCountToken.toNonNegativeCountOrNull()
+            ?: return invalidCount("tab")
+        if (tabCount > (tokens.size - cursor) / MIN_TAB_HEADER_TOKEN_COUNT) {
+            return truncated()
+        }
+
+        val problems = mutableListOf<TabNavigationSnapshotEnvelopeProblem>()
+        val tabs = ArrayList<TabNavigationStateSnapshot.Tab>(tabCount)
+        repeat(tabCount) { tabIndex ->
+            val tabId = nextToken() ?: return truncated()
+            val historyTokenCountToken = nextToken() ?: return truncated()
+            val historyTokenCount = historyTokenCountToken.toNonNegativeCountOrNull()
+                ?: return invalidCount("history token")
+            val remainingTokenCount = tokens.size - cursor
+            if (historyTokenCount > remainingTokenCount) return truncated()
+
+            val historyPayload = ArrayList(tokens.subList(cursor, cursor + historyTokenCount))
+            cursor += historyTokenCount
+            when (val history = NavigationSnapshotEnvelopeCodec.decode(historyPayload)) {
+                is NavigationSnapshotEnvelopeDecodeResult.Decoded ->
+                    tabs += TabNavigationStateSnapshot.Tab(
+                        id = tabId,
+                        history = history.snapshot,
+                    )
+                is NavigationSnapshotEnvelopeDecodeResult.Rejected ->
+                    problems += history.problems.map { problem ->
+                        TabNavigationSnapshotEnvelopeProblem.HistoryEnvelopeProblem(
+                            tabIndex = tabIndex,
+                            tabId = tabId,
+                            problem = problem,
+                        )
+                    }
+            }
+        }
+
+        if (cursor != tokens.size) {
+            return invalid(
+                code = TRAILING_TOKENS_CODE,
+                message = "Tab navigation payload contains data after its declared tabs.",
+            )
+        }
+        if (problems.isNotEmpty()) {
+            return TabNavigationSnapshotEnvelopeDecodeResult.Rejected(problems)
+        }
+
+        return TabNavigationSnapshotEnvelopeDecodeResult.Decoded(
+            TabNavigationStateSnapshot(
+                version = snapshotVersion,
+                selectedTabId = selectedTabId,
+                tabs = tabs,
+            ),
+        )
+    }
+
+    private fun String.toNonNegativeCountOrNull(): Int? =
+        toIntOrNull()?.takeIf { count -> count >= 0 }
+
+    private fun invalidCount(subject: String): TabNavigationSnapshotEnvelopeDecodeResult =
+        invalid(
+            code = INVALID_COUNT_CODE,
+            message = "Tab navigation $subject count must be a non-negative integer.",
+        )
+
+    private fun invalid(
+        code: String,
+        message: String,
+    ): TabNavigationSnapshotEnvelopeDecodeResult =
+        TabNavigationSnapshotEnvelopeDecodeResult.Rejected(
+            listOf(TabNavigationSnapshotEnvelopeProblem.InvalidPayload(code, message)),
+        )
+
+    private const val MAGIC = "udf-tab-nav"
+    private const val CURRENT_ENVELOPE_VERSION = 1
+    private const val MIN_TAB_HEADER_TOKEN_COUNT = 2
+
+    private const val WRONG_TYPE_CODE = "wrong_type"
+    private const val INVALID_PAYLOAD_CODE = "invalid_payload"
+    private const val INVALID_MAGIC_CODE = "invalid_magic"
+    private const val INVALID_ENVELOPE_VERSION_CODE = "invalid_envelope_version"
+    private const val INVALID_SNAPSHOT_VERSION_CODE = "invalid_snapshot_version"
+    private const val INVALID_COUNT_CODE = "invalid_count"
+    private const val TRUNCATED_CODE = "truncated"
+    private const val TRAILING_TOKENS_CODE = "trailing_tokens"
+}
+
+private fun <T> immutableTabEnvelopeListCopy(source: Collection<T>): List<T> =
+    Collections.unmodifiableList(ArrayList(source))

--- a/app/src/test/java/com/shmakov/udf/SavedStateHandleTabNavigationStorageContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/SavedStateHandleTabNavigationStorageContractTest.kt
@@ -1,0 +1,436 @@
+package com.shmakov.udf
+
+import androidx.lifecycle.SavedStateHandle
+import com.shmakov.udf.navigation.Account
+import com.shmakov.udf.navigation.Accounts
+import com.shmakov.udf.navigation.BackStackEntry
+import com.shmakov.udf.navigation.Card
+import com.shmakov.udf.navigation.Cards
+import com.shmakov.udf.navigation.ContentRoute
+import com.shmakov.udf.navigation.DemoRouteCodec
+import com.shmakov.udf.navigation.EncodedRoute
+import com.shmakov.udf.navigation.EntryId
+import com.shmakov.udf.navigation.Home
+import com.shmakov.udf.navigation.NavState
+import com.shmakov.udf.navigation.NavStateCreationResult
+import com.shmakov.udf.navigation.NavStateSnapshot
+import com.shmakov.udf.navigation.Route
+import com.shmakov.udf.navigation.RouteCodec
+import com.shmakov.udf.navigation.RouteCodecError
+import com.shmakov.udf.navigation.RouteDecodeResult
+import com.shmakov.udf.navigation.RouteEncodeResult
+import com.shmakov.udf.navigation.SnapshotProblem
+import com.shmakov.udf.navigation.TabId
+import com.shmakov.udf.navigation.TabNavigationSnapshotProblem
+import com.shmakov.udf.navigation.TabNavigationSnapshotResult
+import com.shmakov.udf.navigation.TabNavigationState
+import com.shmakov.udf.navigation.TabNavigationStateSnapshot
+import com.shmakov.udf.navigation.TabNavigationStateProblem
+import com.shmakov.udf.navigation.TabState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SavedStateHandleTabNavigationStorageContractTest {
+
+    @Test
+    fun `missing payload is distinct from rejection and does not write`() {
+        val handle = SavedStateHandle()
+        val storage = SavedStateHandleTabNavigationStorage(handle, DemoRouteCodec)
+
+        val result = storage.restore()
+
+        assertTrue(result is TabNavigationRestoreResult.Missing)
+        assertTrue(handle.keys().isEmpty())
+    }
+
+    @Test
+    fun `injected codec saves one payload and a fresh handle restores the exact graph`() {
+        val first = tab(
+            "first",
+            entry("first-root", ConsumerRoute("first-root")),
+            entry("first-details", ConsumerRoute("first-details")),
+        )
+        val second = tab(
+            "second",
+            entry("second-root", ConsumerRoute("second-root")),
+        )
+        val original = graph(second.id, first, second)
+        val firstHandle = SavedStateHandle(mapOf(UNRELATED_KEY to "keep"))
+        val firstStorage = SavedStateHandleTabNavigationStorage(firstHandle, ConsumerCodec)
+
+        assertSaved(firstStorage.save(original))
+
+        val navigationKey = tabNavigationKey(firstHandle)
+        val payload = savedPayload(firstHandle, navigationKey)
+        assertEquals("keep", firstHandle.get<String>(UNRELATED_KEY))
+        assertEquals("udf-tab-nav", payload.first())
+        assertTrue((payload as List<*>).all { token -> token is String })
+
+        val recreatedHandle = SavedStateHandle(
+            mapOf(
+                navigationKey to ArrayList(payload),
+                UNRELATED_KEY to "keep",
+            ),
+        )
+        val restored = restored(
+            SavedStateHandleTabNavigationStorage(recreatedHandle, ConsumerCodec).restore(),
+        )
+
+        assertEquals(original, restored)
+        assertEquals(second.id, restored.selectedTabId)
+        assertEquals(listOf("first", "second"), restored.tabs.map { it.id.value })
+        assertEquals(
+            original.tabs.flatMap { tab -> tab.history.entries.map { it.id } },
+            restored.tabs.flatMap { tab -> tab.history.entries.map { it.id } },
+        )
+        assertEquals("keep", recreatedHandle.get<String>(UNRELATED_KEY))
+    }
+
+    @Test
+    fun `second save replaces the complete payload without aliasing the previous value`() {
+        val firstGraph = graph(
+            TabId("accounts"),
+            tab("accounts", entry("accounts-root", Accounts)),
+            tab("cards", entry("cards-root", Cards)),
+        )
+        val secondGraph = graph(
+            TabId("cards"),
+            tab(
+                "accounts",
+                entry("new-accounts-root", Accounts),
+                entry("account-42", Account(accountId = 42)),
+            ),
+            tab(
+                "cards",
+                entry("new-cards-root", Cards),
+                entry("card-7", Card(cardId = 7)),
+            ),
+        )
+        val handle = SavedStateHandle()
+        val storage = SavedStateHandleTabNavigationStorage(handle, DemoRouteCodec)
+
+        assertSaved(storage.save(firstGraph))
+        val key = handle.keys().single()
+        val firstOwnedPayload = checkNotNull(handle.get<ArrayList<String>>(key))
+        val firstValue = ArrayList(firstOwnedPayload)
+
+        assertSaved(storage.save(secondGraph))
+        val secondOwnedPayload = checkNotNull(handle.get<ArrayList<String>>(key))
+
+        assertNotSame(firstOwnedPayload, secondOwnedPayload)
+        assertEquals(firstValue, firstOwnedPayload)
+        assertEquals(secondGraph, restored(storage.restore()))
+        assertEquals(setOf(key), handle.keys())
+    }
+
+    @Test
+    fun `snapshot failure in a later tab clears only the stale graph payload`() {
+        val valid = graph(
+            TabId("accounts"),
+            tab("accounts", entry("accounts-root", Accounts)),
+            tab("cards", entry("cards-root", Cards)),
+        )
+        val handle = SavedStateHandle(mapOf(UNRELATED_KEY to "keep"))
+        val storage = SavedStateHandleTabNavigationStorage(handle, DemoRouteCodec)
+        assertSaved(storage.save(valid))
+        val key = tabNavigationKey(handle)
+        val unsupportedEntry = entry("unsupported", UnsupportedContent)
+        val unsupported = graph(
+            TabId("accounts"),
+            valid.tabs.first(),
+            tab("cards", entry("cards-root-2", Cards), unsupportedEntry),
+        )
+
+        val problems = failed(storage.save(unsupported))
+
+        val problem = problems.single() as TabNavigationSaveProblem.Snapshot
+        assertEquals(
+            TabNavigationSnapshotProblem.HistoryProblem(
+                tabIndex = 1,
+                tabId = "cards",
+                problem = SnapshotProblem.RouteEncodeFailed(
+                    index = 1,
+                    entryId = unsupportedEntry.id,
+                    error = RouteCodecError(
+                        code = "unsupported_route",
+                        message = "Route is not supported by DemoRouteCodec.",
+                    ),
+                ),
+            ),
+            problem.problem,
+        )
+        assertFalse(handle.contains(key))
+        assertEquals("keep", handle.get<String>(UNRELATED_KEY))
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (problems as MutableList<TabNavigationSaveProblem>).clear()
+        }
+    }
+
+    @Test
+    fun `corrupt envelope is rejected clears only its key and then becomes missing`() {
+        val handle = SavedStateHandle(mapOf(UNRELATED_KEY to "keep"))
+        val storage = SavedStateHandleTabNavigationStorage(handle, DemoRouteCodec)
+        assertSaved(storage.save(demoGraph()))
+        val key = tabNavigationKey(handle)
+        handle[key] = arrayListOf("not-tab-nav", "1", "1", "accounts", "0")
+
+        val problems = rejected(storage.restore())
+
+        assertEquals(
+            listOf(
+                TabNavigationRestoreProblem.InvalidEnvelope(
+                    TabNavigationSnapshotEnvelopeProblem.InvalidPayload(
+                        code = "invalid_magic",
+                        message = "Tab navigation payload has an unknown magic header.",
+                    ),
+                ),
+            ),
+            problems,
+        )
+        assertFalse(handle.contains(key))
+        assertEquals("keep", handle.get<String>(UNRELATED_KEY))
+        assertTrue(storage.restore() is TabNavigationRestoreResult.Missing)
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (problems as MutableList<TabNavigationRestoreProblem>).clear()
+        }
+    }
+
+    @Test
+    fun `valid envelopes with invalid graph snapshots are rejected whole and cleared`() {
+        val validSnapshot = snapshotSuccess(demoGraph().toSnapshot(DemoRouteCodec))
+        val cases = listOf(
+            InvalidGraphCase(
+                snapshot = TabNavigationStateSnapshot(
+                    version = TabNavigationStateSnapshot.CURRENT_VERSION + 1,
+                    selectedTabId = validSnapshot.selectedTabId,
+                    tabs = validSnapshot.tabs,
+                ),
+                expectedProblem = TabNavigationSnapshotProblem.UnsupportedVersion(
+                    TabNavigationStateSnapshot.CURRENT_VERSION + 1,
+                ),
+            ),
+            InvalidGraphCase(
+                snapshot = TabNavigationStateSnapshot(
+                    version = TabNavigationStateSnapshot.CURRENT_VERSION,
+                    selectedTabId = "accounts",
+                    tabs = listOf(
+                        validSnapshot.tabs.first(),
+                        snapshotTab(
+                            "cards",
+                            snapshotEntry("cards-root", "cards/v1"),
+                            snapshotEntry("future", "future/v99"),
+                        ),
+                    ),
+                ),
+                expectedProblem = TabNavigationSnapshotProblem.HistoryProblem(
+                    tabIndex = 1,
+                    tabId = "cards",
+                    problem = SnapshotProblem.RouteDecodeFailed(
+                        index = 1,
+                        entryId = "future",
+                        routeType = "future/v99",
+                        error = RouteCodecError(
+                            code = "unknown_route_type",
+                            message = "Unknown route type: future/v99",
+                        ),
+                    ),
+                ),
+            ),
+            InvalidGraphCase(
+                snapshot = TabNavigationStateSnapshot(
+                    version = TabNavigationStateSnapshot.CURRENT_VERSION,
+                    selectedTabId = "accounts",
+                    tabs = listOf(
+                        snapshotTab("accounts", snapshotEntry("shared", "accounts/v1")),
+                        snapshotTab("cards", snapshotEntry("shared", "cards/v1")),
+                    ),
+                ),
+                expectedProblem = TabNavigationSnapshotProblem.InvalidState(
+                    TabNavigationStateProblem.DuplicateEntryId(
+                        entryId = EntryId("shared"),
+                        firstTabId = TabId("accounts"),
+                        duplicateTabId = TabId("cards"),
+                        firstTabIndex = 0,
+                        duplicateTabIndex = 1,
+                    ),
+                ),
+            ),
+        )
+
+        cases.forEach { case ->
+            val handle = SavedStateHandle(mapOf(UNRELATED_KEY to "keep"))
+            val storage = SavedStateHandleTabNavigationStorage(handle, DemoRouteCodec)
+            assertSaved(storage.save(demoGraph()))
+            val key = tabNavigationKey(handle)
+            handle[key] = TabNavigationSnapshotEnvelopeCodec.encode(case.snapshot)
+
+            val problems = rejected(storage.restore())
+            assertEquals(
+                listOf(TabNavigationRestoreProblem.InvalidSnapshot(case.expectedProblem)),
+                problems,
+            )
+            assertFalse(handle.contains(key))
+            assertEquals("keep", handle.get<String>(UNRELATED_KEY))
+        }
+    }
+
+    @Test
+    fun `linear and tab storage use separate keys and envelope magic`() {
+        val handle = SavedStateHandle()
+        assertTrue(
+            SavedNavigationStateStore(handle).save(NavState.startAt(Home))
+                is NavigationSaveResult.Saved,
+        )
+        val tabStorage = SavedStateHandleTabNavigationStorage(handle, DemoRouteCodec)
+        assertSaved(tabStorage.save(demoGraph()))
+
+        assertEquals(2, handle.keys().size)
+        assertEquals(
+            setOf("udf-nav", "udf-tab-nav"),
+            handle.keys().map { key ->
+                checkNotNull(handle.get<ArrayList<String>>(key)).first()
+            }.toSet(),
+        )
+        assertEquals(demoGraph(), restored(tabStorage.restore()))
+        assertTrue(SavedNavigationStateStore(handle).restore() is NavigationRestoreResult.Restored)
+    }
+
+    private fun demoGraph(): TabNavigationState = graph(
+        TabId("cards"),
+        tab(
+            "accounts",
+            entry("accounts-root", Accounts),
+            entry("account-42", Account(accountId = 42)),
+        ),
+        tab(
+            "cards",
+            entry("cards-root", Cards),
+            entry("card-7", Card(cardId = 7)),
+        ),
+    )
+
+    private fun graph(
+        selectedTabId: TabId,
+        vararg tabs: TabState,
+    ): TabNavigationState = TabNavigationState.create(selectedTabId, tabs.toList())
+
+    private fun tab(
+        id: String,
+        vararg entries: BackStackEntry,
+    ): TabState = TabState(TabId(id), navigation(*entries))
+
+    private fun navigation(vararg entries: BackStackEntry): NavState =
+        when (val result = NavState.fromEntries(entries.toList())) {
+            is NavStateCreationResult.Valid -> result.state
+            is NavStateCreationResult.Invalid -> throw AssertionError(result.problems)
+        }
+
+    private fun entry(id: String, route: Route): BackStackEntry =
+        BackStackEntry(EntryId(id), route)
+
+    private fun snapshotTab(
+        id: String,
+        vararg entries: NavStateSnapshot.Entry,
+    ): TabNavigationStateSnapshot.Tab = TabNavigationStateSnapshot.Tab(
+        id = id,
+        history = NavStateSnapshot(
+            version = NavStateSnapshot.CURRENT_VERSION,
+            entries = entries.toList(),
+        ),
+    )
+
+    private fun snapshotEntry(
+        id: String,
+        routeType: String,
+        vararg arguments: Pair<String, String>,
+    ): NavStateSnapshot.Entry = NavStateSnapshot.Entry(
+        id = id,
+        routeType = routeType,
+        arguments = mapOf(*arguments),
+    )
+
+    private fun snapshotSuccess(
+        result: TabNavigationSnapshotResult<TabNavigationStateSnapshot>,
+    ): TabNavigationStateSnapshot = when (result) {
+        is TabNavigationSnapshotResult.Success -> result.value
+        is TabNavigationSnapshotResult.Failure -> throw AssertionError(result.problems)
+    }
+
+    private fun assertSaved(result: TabNavigationSaveResult) {
+        when (result) {
+            TabNavigationSaveResult.Saved -> Unit
+            is TabNavigationSaveResult.Failed -> throw AssertionError(result.problems)
+        }
+    }
+
+    private fun failed(result: TabNavigationSaveResult): List<TabNavigationSaveProblem> =
+        when (result) {
+            TabNavigationSaveResult.Saved -> throw AssertionError("Expected save failure")
+            is TabNavigationSaveResult.Failed -> result.problems
+        }
+
+    private fun restored(result: TabNavigationRestoreResult): TabNavigationState = when (result) {
+        TabNavigationRestoreResult.Missing -> throw AssertionError("Expected restored graph")
+        is TabNavigationRestoreResult.Restored -> result.state
+        is TabNavigationRestoreResult.Rejected -> throw AssertionError(result.problems)
+    }
+
+    private fun rejected(
+        result: TabNavigationRestoreResult,
+    ): List<TabNavigationRestoreProblem> = when (result) {
+        TabNavigationRestoreResult.Missing -> throw AssertionError("Expected rejection")
+        is TabNavigationRestoreResult.Restored -> throw AssertionError(result.state)
+        is TabNavigationRestoreResult.Rejected -> result.problems
+    }
+
+    private fun tabNavigationKey(handle: SavedStateHandle): String =
+        (handle.keys() - UNRELATED_KEY).single()
+
+    private fun savedPayload(
+        handle: SavedStateHandle,
+        key: String,
+    ): ArrayList<String> = checkNotNull(handle.get<ArrayList<String>>(key)).let(::ArrayList)
+
+    private data class InvalidGraphCase(
+        val snapshot: TabNavigationStateSnapshot,
+        val expectedProblem: TabNavigationSnapshotProblem,
+    )
+
+    private data class ConsumerRoute(val slug: String) : ContentRoute
+
+    private object UnsupportedContent : ContentRoute
+
+    private object ConsumerCodec : RouteCodec {
+        override fun encode(route: Route): RouteEncodeResult = when (route) {
+            is ConsumerRoute -> RouteEncodeResult.Success(
+                EncodedRoute("consumer/v1", mapOf("slug" to route.slug)),
+            )
+            else -> RouteEncodeResult.Failure(
+                RouteCodecError("unsupported", "Unsupported consumer route."),
+            )
+        }
+
+        override fun decode(
+            type: String,
+            arguments: Map<String, String>,
+        ): RouteDecodeResult = if (
+            type == "consumer/v1" && arguments.keys == setOf("slug")
+        ) {
+            RouteDecodeResult.Success(ConsumerRoute(arguments.getValue("slug")))
+        } else {
+            RouteDecodeResult.Failure(
+                RouteCodecError("invalid_consumer_route", "Invalid consumer route."),
+            )
+        }
+    }
+
+    private companion object {
+        const val UNRELATED_KEY = "unrelated"
+    }
+}

--- a/app/src/test/java/com/shmakov/udf/TabNavigationSnapshotEnvelopeContractTest.kt
+++ b/app/src/test/java/com/shmakov/udf/TabNavigationSnapshotEnvelopeContractTest.kt
@@ -1,0 +1,403 @@
+package com.shmakov.udf
+
+import com.shmakov.udf.navigation.NavStateSnapshot
+import com.shmakov.udf.navigation.DemoRouteCodec
+import com.shmakov.udf.navigation.EntryId
+import com.shmakov.udf.navigation.SnapshotProblem
+import com.shmakov.udf.navigation.TabNavigationSnapshotProblem
+import com.shmakov.udf.navigation.TabNavigationSnapshotResult
+import com.shmakov.udf.navigation.TabNavigationState
+import com.shmakov.udf.navigation.TabNavigationStateSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.LinkedHashMap
+
+class TabNavigationSnapshotEnvelopeContractTest {
+
+    @Test
+    fun `wire is one flat Bundle-safe value with exact ordered leaf payloads`() {
+        val snapshot = TabNavigationStateSnapshot(
+            version = TabNavigationStateSnapshot.CURRENT_VERSION,
+            selectedTabId = "cards",
+            tabs = listOf(
+                snapshotTab(
+                    "accounts",
+                    snapshotEntry("accounts-root", "accounts/v1"),
+                    snapshotEntry("account-42", "account/v1", "accountId" to "42"),
+                ),
+                snapshotTab(
+                    "cards",
+                    snapshotEntry("cards-root", "cards/v1"),
+                    snapshotEntry("card-7", "card/v1", "cardId" to "7"),
+                ),
+            ),
+        )
+
+        val encoded = TabNavigationSnapshotEnvelopeCodec.encode(snapshot)
+
+        assertEquals(ArrayList::class.java, encoded.javaClass)
+        assertTrue((encoded as List<*>).all { token -> token is String })
+        assertEquals(
+            arrayListOf(
+                "udf-tab-nav", "1", "1", "cards", "2",
+                "accounts", "12",
+                "udf-nav", "1", "1", "2",
+                "accounts-root", "accounts/v1", "0",
+                "account-42", "account/v1", "1", "accountId", "42",
+                "cards", "12",
+                "udf-nav", "1", "1", "2",
+                "cards-root", "cards/v1", "0",
+                "card-7", "card/v1", "1", "cardId", "7",
+            ),
+            encoded,
+        )
+
+        assertEquals(
+            snapshot,
+            decoded(TabNavigationSnapshotEnvelopeCodec.decode(ArrayList(encoded))),
+        )
+    }
+
+    @Test
+    fun `equal snapshots encode deterministically and decoded value never aliases payload`() {
+        val reverseArguments = LinkedHashMap<String, String>().apply {
+            put("zeta", "last")
+            put("alpha", "first")
+        }
+        val sortedArguments = linkedMapOf("alpha" to "first", "zeta" to "last")
+        val reverseSnapshot = oneTabSnapshot(
+            snapshotEntry("entry", "consumer/v1", *reverseArguments.toList().toTypedArray()),
+        )
+        val sortedSnapshot = oneTabSnapshot(
+            snapshotEntry("entry", "consumer/v1", *sortedArguments.toList().toTypedArray()),
+        )
+
+        val reversePayload = TabNavigationSnapshotEnvelopeCodec.encode(reverseSnapshot)
+        val sortedPayload = TabNavigationSnapshotEnvelopeCodec.encode(sortedSnapshot)
+
+        assertEquals(sortedPayload, reversePayload)
+        assertEquals(
+            arrayListOf(
+                "udf-tab-nav", "1", "1", "accounts", "1",
+                "accounts", "11",
+                "udf-nav", "1", "1", "1",
+                "entry", "consumer/v1", "2",
+                "alpha", "first", "zeta", "last",
+            ),
+            reversePayload,
+        )
+
+        val decoded = decoded(TabNavigationSnapshotEnvelopeCodec.decode(reversePayload))
+        reversePayload.clear()
+
+        assertEquals(sortedSnapshot, decoded)
+        assertEquals(
+            mapOf("alpha" to "first", "zeta" to "last"),
+            decoded.tabs.single().history.entries.single().arguments,
+        )
+    }
+
+    @Test
+    fun `outer corruption and unsafe counts are typed all or nothing rejections`() {
+        val cases = listOf(
+            InvalidPayloadCase(7, "wrong_type"),
+            InvalidPayloadCase(
+                arrayListOf<Any>("udf-tab-nav", 1, "1", "accounts", "0"),
+                "wrong_type",
+            ),
+            InvalidPayloadCase(arrayListOf("not-tab-nav", "1", "1", "accounts", "0"), "invalid_magic"),
+            InvalidPayloadCase(arrayListOf("udf-tab-nav", "not-an-int", "1", "accounts", "0"), "invalid_envelope_version"),
+            InvalidPayloadCase(arrayListOf("udf-tab-nav", "1", "not-an-int", "accounts", "0"), "invalid_snapshot_version"),
+            InvalidPayloadCase(arrayListOf("udf-tab-nav", "1", "1"), "truncated"),
+            InvalidPayloadCase(arrayListOf("udf-tab-nav", "1", "1", "accounts", "not-an-int"), "invalid_count"),
+            InvalidPayloadCase(arrayListOf("udf-tab-nav", "1", "1", "accounts", "-1"), "invalid_count"),
+            InvalidPayloadCase(
+                arrayListOf("udf-tab-nav", "1", "1", "accounts", Int.MAX_VALUE.toString()),
+                "truncated",
+            ),
+            InvalidPayloadCase(arrayListOf("udf-tab-nav", "1", "1", "accounts", "1"), "truncated"),
+            InvalidPayloadCase(
+                arrayListOf("udf-tab-nav", "1", "1", "accounts", "1", "accounts"),
+                "truncated",
+            ),
+            InvalidPayloadCase(
+                arrayListOf(
+                    "udf-tab-nav", "1", "1", "accounts", "1", "accounts", "not-an-int",
+                ),
+                "invalid_count",
+            ),
+            InvalidPayloadCase(
+                arrayListOf("udf-tab-nav", "1", "1", "accounts", "1", "accounts", "-1"),
+                "invalid_count",
+            ),
+            InvalidPayloadCase(
+                arrayListOf(
+                    "udf-tab-nav", "1", "1", "accounts", "1", "accounts", "2147483648",
+                ),
+                "invalid_count",
+            ),
+            InvalidPayloadCase(
+                arrayListOf(
+                    "udf-tab-nav", "1", "1", "accounts", "1", "accounts",
+                    Int.MAX_VALUE.toString(),
+                ),
+                "truncated",
+            ),
+            InvalidPayloadCase(
+                arrayListOf("udf-tab-nav", "1", "1", "accounts", "0", "trailing"),
+                "trailing_tokens",
+            ),
+        )
+
+        cases.forEach { case ->
+            val problems = rejected(TabNavigationSnapshotEnvelopeCodec.decode(case.value))
+            val problem = problems.single()
+
+            assertTrue(
+                "Expected InvalidPayload for ${case.expectedCode}, got $problem",
+                problem is TabNavigationSnapshotEnvelopeProblem.InvalidPayload,
+            )
+            problem as TabNavigationSnapshotEnvelopeProblem.InvalidPayload
+            assertEquals(case.expectedCode, problem.code)
+            assertTrue(problem.message.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `valid segments aggregate nested leaf failures in tab major order with raw IDs`() {
+        val invalidMagicLeaf = arrayListOf("not-udf-nav", "1", "1", "0")
+        val unsupportedLeafEnvelope = arrayListOf("udf-nav", "2", "1", "0")
+        val payload = tabPayload(
+            selectedTabId = "accounts",
+            tabs = listOf(
+                "accounts" to invalidMagicLeaf,
+                "cards" to unsupportedLeafEnvelope,
+            ),
+        )
+
+        val problems = rejected(TabNavigationSnapshotEnvelopeCodec.decode(payload))
+
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotEnvelopeProblem.HistoryEnvelopeProblem(
+                    tabIndex = 0,
+                    tabId = "accounts",
+                    problem = NavigationSnapshotEnvelopeProblem.InvalidPayload(
+                        code = "invalid_magic",
+                        message = "Navigation payload has an unknown magic header.",
+                    ),
+                ),
+                TabNavigationSnapshotEnvelopeProblem.HistoryEnvelopeProblem(
+                    tabIndex = 1,
+                    tabId = "cards",
+                    problem = NavigationSnapshotEnvelopeProblem.UnsupportedEnvelopeVersion(2),
+                ),
+            ),
+            problems,
+        )
+        assertThrows(UnsupportedOperationException::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            (problems as MutableList<TabNavigationSnapshotEnvelopeProblem>).clear()
+        }
+    }
+
+    @Test
+    fun `nested leaf unsafe counts stay bounded and contextual`() {
+        val hugeEntryCount = arrayListOf(
+            "udf-nav", "1", "1", Int.MAX_VALUE.toString(),
+        )
+        val hugeArgumentCount = arrayListOf(
+            "udf-nav", "1", "1", "1",
+            "entry", "consumer/v1", Int.MAX_VALUE.toString(),
+        )
+        val payload = tabPayload(
+            selectedTabId = "accounts",
+            tabs = listOf(
+                "accounts" to hugeEntryCount,
+                "cards" to hugeArgumentCount,
+            ),
+        )
+
+        val problems = rejected(TabNavigationSnapshotEnvelopeCodec.decode(payload))
+
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotEnvelopeProblem.HistoryEnvelopeProblem(
+                    tabIndex = 0,
+                    tabId = "accounts",
+                    problem = NavigationSnapshotEnvelopeProblem.InvalidPayload(
+                        code = "truncated",
+                        message = "Navigation payload ended before its declared data was complete.",
+                    ),
+                ),
+                TabNavigationSnapshotEnvelopeProblem.HistoryEnvelopeProblem(
+                    tabIndex = 1,
+                    tabId = "cards",
+                    problem = NavigationSnapshotEnvelopeProblem.InvalidPayload(
+                        code = "truncated",
+                        message = "Navigation payload ended before its declared data was complete.",
+                    ),
+                ),
+            ),
+            problems,
+        )
+    }
+
+    @Test
+    fun `outer graph and nested leaf versions remain independent`() {
+        val validLeaf = NavigationSnapshotEnvelopeCodec.encode(
+            NavStateSnapshot(
+                version = NavStateSnapshot.CURRENT_VERSION,
+                entries = listOf(snapshotEntry("accounts-root", "accounts/v1")),
+            ),
+        )
+        val unsupportedOuterEnvelope = tabPayload(
+            envelopeVersion = 2,
+            selectedTabId = "accounts",
+            tabs = listOf("accounts" to validLeaf),
+        )
+        assertEquals(
+            listOf(TabNavigationSnapshotEnvelopeProblem.UnsupportedEnvelopeVersion(2)),
+            rejected(TabNavigationSnapshotEnvelopeCodec.decode(unsupportedOuterEnvelope)),
+        )
+
+        val unsupportedGraphSnapshot = tabPayload(
+            graphSnapshotVersion = TabNavigationStateSnapshot.CURRENT_VERSION + 1,
+            selectedTabId = "accounts",
+            tabs = listOf("accounts" to validLeaf),
+        )
+        val decodedGraphSnapshot = decoded(
+            TabNavigationSnapshotEnvelopeCodec.decode(unsupportedGraphSnapshot),
+        )
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotProblem.UnsupportedVersion(
+                    TabNavigationStateSnapshot.CURRENT_VERSION + 1,
+                ),
+            ),
+            graphProblems(TabNavigationState.restore(decodedGraphSnapshot, DemoRouteCodec)),
+        )
+
+        val unsupportedLeafEnvelope = tabPayload(
+            selectedTabId = "accounts",
+            tabs = listOf("accounts" to arrayListOf("udf-nav", "2", "1", "0")),
+        )
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotEnvelopeProblem.HistoryEnvelopeProblem(
+                    tabIndex = 0,
+                    tabId = "accounts",
+                    problem = NavigationSnapshotEnvelopeProblem.UnsupportedEnvelopeVersion(2),
+                ),
+            ),
+            rejected(TabNavigationSnapshotEnvelopeCodec.decode(unsupportedLeafEnvelope)),
+        )
+
+        val leafSnapshotVersion = NavStateSnapshot.CURRENT_VERSION + 1
+        val unsupportedLeafSnapshot = tabPayload(
+            selectedTabId = "accounts",
+            tabs = listOf(
+                "accounts" to NavigationSnapshotEnvelopeCodec.encode(
+                    NavStateSnapshot(
+                        version = leafSnapshotVersion,
+                        entries = listOf(snapshotEntry("accounts-root", "accounts/v1")),
+                    ),
+                ),
+            ),
+        )
+        val decodedLeafSnapshot = decoded(
+            TabNavigationSnapshotEnvelopeCodec.decode(unsupportedLeafSnapshot),
+        )
+        assertEquals(
+            listOf(
+                TabNavigationSnapshotProblem.HistoryProblem(
+                    tabIndex = 0,
+                    tabId = "accounts",
+                    problem = SnapshotProblem.UnsupportedVersion(leafSnapshotVersion),
+                ),
+            ),
+            graphProblems(TabNavigationState.restore(decodedLeafSnapshot, DemoRouteCodec)),
+        )
+    }
+
+    private fun snapshotTab(
+        id: String,
+        vararg entries: NavStateSnapshot.Entry,
+    ): TabNavigationStateSnapshot.Tab = TabNavigationStateSnapshot.Tab(
+        id = id,
+        history = NavStateSnapshot(
+            version = NavStateSnapshot.CURRENT_VERSION,
+            entries = entries.toList(),
+        ),
+    )
+
+    private fun snapshotEntry(
+        id: String,
+        routeType: String,
+        vararg arguments: Pair<String, String>,
+    ): NavStateSnapshot.Entry = NavStateSnapshot.Entry(
+        id = id,
+        routeType = routeType,
+        arguments = mapOf(*arguments),
+    )
+
+    private fun oneTabSnapshot(
+        vararg entries: NavStateSnapshot.Entry,
+    ): TabNavigationStateSnapshot = TabNavigationStateSnapshot(
+        version = TabNavigationStateSnapshot.CURRENT_VERSION,
+        selectedTabId = "accounts",
+        tabs = listOf(snapshotTab("accounts", *entries)),
+    )
+
+    private fun tabPayload(
+        envelopeVersion: Int = 1,
+        graphSnapshotVersion: Int = TabNavigationStateSnapshot.CURRENT_VERSION,
+        selectedTabId: String,
+        tabs: List<Pair<String, ArrayList<String>>>,
+    ): ArrayList<String> = arrayListOf<String>().apply {
+        add("udf-tab-nav")
+        add(envelopeVersion.toString())
+        add(graphSnapshotVersion.toString())
+        add(selectedTabId)
+        add(tabs.size.toString())
+        tabs.forEach { (tabId, leafPayload) ->
+            add(tabId)
+            add(leafPayload.size.toString())
+            addAll(leafPayload)
+        }
+    }
+
+    private fun decoded(
+        result: TabNavigationSnapshotEnvelopeDecodeResult,
+    ): TabNavigationStateSnapshot = when (result) {
+        is TabNavigationSnapshotEnvelopeDecodeResult.Decoded -> result.snapshot
+        is TabNavigationSnapshotEnvelopeDecodeResult.Rejected -> throw AssertionError(
+            "Expected decoded envelope, got ${result.problems}",
+        )
+    }
+
+    private fun rejected(
+        result: TabNavigationSnapshotEnvelopeDecodeResult,
+    ): List<TabNavigationSnapshotEnvelopeProblem> = when (result) {
+        is TabNavigationSnapshotEnvelopeDecodeResult.Decoded -> throw AssertionError(
+            "Expected rejected envelope, got ${result.snapshot}",
+        )
+        is TabNavigationSnapshotEnvelopeDecodeResult.Rejected -> result.problems
+    }
+
+    private fun graphProblems(
+        result: TabNavigationSnapshotResult<TabNavigationState>,
+    ): List<TabNavigationSnapshotProblem> = when (result) {
+        is TabNavigationSnapshotResult.Success -> throw AssertionError(
+            "Expected graph rejection, got ${result.value}",
+        )
+        is TabNavigationSnapshotResult.Failure -> result.problems
+    }
+
+    private data class InvalidPayloadCase(
+        val value: Any?,
+        val expectedCode: String,
+    )
+}

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -34,7 +34,9 @@
 
 Открытые `ContentRoute` и `ModalRoute` позволяют приложению объявлять собственные routes. Versioned primitive snapshot отделён от route objects; приложение подключает их через `RouteCodec`, а восстановление всегда повторно использует validation `NavState`.
 
-`TabNavigationState` — следующий pure composition layer: ordered list хранит стабильные `TabId`, отдельный non-empty `NavState` каждого tab и выбранный tab, а validator обеспечивает graph-wide уникальность `EntryId`. `TabReducer` разделяет container actions и exact leaf navigation, оставляет inactive histories теми же instances и поддерживает атомарные `OpenTab`/`ReplaceGraph`. `TabNavigationStateSnapshot` композиционно сохраняет selected tab, порядок tabs и каждый leaf `NavStateSnapshot` через один application `RouteCodec`; nested problems получают tab index/ID, а итоговый graph повторно проходит `TabNavigationState.fromTabs`. Graph использует отдельные `TabNavigationSnapshotResult`/`TabNavigationSnapshotProblem`, поэтому composition-specific diagnostics не расширяют sealed leaf `SnapshotProblem`. Outer, leaf и route payload versions независимы. Snapshot не содержит transition metadata и сам по себе ещё не является Android lifecycle evidence.
+`TabNavigationState` — следующий pure composition layer: ordered list хранит стабильные `TabId`, отдельный non-empty `NavState` каждого tab и выбранный tab, а validator обеспечивает graph-wide уникальность `EntryId`. `TabReducer` разделяет container actions и exact leaf navigation, оставляет inactive histories теми же instances и поддерживает атомарные `OpenTab`/`ReplaceGraph`. `TabNavigationStateSnapshot` композиционно сохраняет selected tab, порядок tabs и каждый leaf `NavStateSnapshot` через один application `RouteCodec`; nested problems получают tab index/ID, а итоговый graph повторно проходит `TabNavigationState.fromTabs`. Graph использует отдельные `TabNavigationSnapshotResult`/`TabNavigationSnapshotProblem`, поэтому composition-specific diagnostics не расширяют sealed leaf `SnapshotProblem`. Outer, leaf и route payload versions независимы.
+
+Internal `SavedStateHandleTabNavigationStorage` проводит весь graph через один tab-specific `ArrayList<String>` и обязательный application `RouteCodec`. Outer envelope содержит length-prefixed полные payload-ы существующего linear leaf-envelope; это переиспользует strict parser и независимо версионирует graph envelope, graph snapshot, leaf envelope, leaf snapshot и route payload. Decode агрегирует ошибки валидных leaf segments с tab context; повреждённые outer boundaries отклоняются целиком. Save/restore очищают только tab-specific stale key, не выбирают fallback и не затрагивают linear storage. Storage adapter не владеет Flow/frame/revision/transition и сам по себе ещё не является Activity lifecycle evidence.
 
 Navigation input представлен закрытым набором typed `NavAction`, а `NavReducer.reduce(state, action)` является чистой Kotlin-функцией. Результат — `NavReduction.Changed(state, transition)` либо `NavReduction.Unchanged(state, reason)`. Action factories материализуют identity новых entries до reduction, поэтому reducer не генерирует случайные значения.
 
@@ -295,7 +297,7 @@ Route, entry identity, validated `NavState`, primitive snapshot, `SavedStateHand
 
 - Должна ли каноническая навигация остаться линейной историей или стать явным деревом?
 - Как превратить внутреннее exact-intent matching в простой application-defined animation policy API?
-- Как встроить уже выделенный stateful tab graph в store/renderer и per-entry saveable state, не усложнив линейный базовый API?
+- Как встроить уже выделенный и сохраняемый stateful tab graph в owner/store, renderer и per-entry saveable state, не усложнив линейный базовый API?
 - Как predictive Back интегрируется с reducer-owned navigation state?
 - Может ли Navigation Compose помочь с платформенной интеграцией, не становясь владельцем канонической истории?
 

--- a/docs/evidence/issue-48/README.md
+++ b/docs/evidence/issue-48/README.md
@@ -1,0 +1,69 @@
+# Issue #48 — one-key SavedStateHandle storage for the complete tab graph
+
+## Scope
+
+This slice adds an internal Android storage boundary for the complete `TabNavigationState` without
+adding an observable state owner. A flat outer envelope stores selected tab and ordered tabs; each
+tab contains a length-prefixed complete payload from the existing strict leaf envelope codec.
+
+`SavedStateHandleTabNavigationStorage` accepts one application `RouteCodec`, reads and replaces one
+tab-specific `ArrayList<String>`, returns typed save/restore outcomes, and clears only its own stale
+key on rejection. It does not dispatch actions, publish frames, choose a fallback, migrate the
+linear payload, or persist transition metadata.
+
+## TDD evidence
+
+1. Exact outer wire/round-trip and missing-storage contracts were added before production.
+2. The observed RED run failed at test compilation because the tab envelope codec/decode results,
+   storage adapter, and typed restoration results did not exist.
+3. A minimal safe implementation made the first two contracts pass.
+4. Tests were expanded to 13 focused contracts covering deterministic wire, outer and nested
+   corruption, unsafe counts, version independence, injected application codec, copied-handle
+   restoration, atomic replacement, stale cleanup, invalid graph snapshots, immutable problems,
+   and separate linear/tab keys.
+5. The expanded focused suite and the forced full project gate passed.
+
+## Verified contracts
+
+- one flat `ArrayList<String>` contains graph header and ordered length-prefixed leaf payloads;
+- equal snapshots encode deterministically and sorted route arguments reuse the leaf contract;
+- decoded snapshots do not alias the caller-owned payload;
+- wrong types, magic, versions, counts, lengths, truncation, overflow, and trailing tokens are
+  typed all-or-nothing outer failures;
+- huge outer, leaf entry, and leaf argument counts are rejected before unsafe allocation;
+- structurally bounded leaf failures aggregate tab-major with raw tab ID and leaf diagnostics;
+- graph-envelope, graph-snapshot, leaf-envelope, leaf-snapshot, and route versions stay distinct;
+- one injected codec saves and restores arbitrary application routes across multiple tabs;
+- a copied primitive payload in a fresh handle restores selected/order/histories/routes/exact IDs;
+- a second save replaces the whole payload with a new owned `ArrayList` and no partial graph;
+- save snapshot failure and restore rejection clear only the tab key and preserve unrelated keys;
+- unsupported graph snapshot, bad route, and cross-tab ID collision reject the complete graph;
+- adapter tests preserve the exact tab, entry, route, and cross-tab collision diagnostics;
+- `Missing` is distinct from `Rejected`, and storage never writes or chooses fallback on missing;
+- `SavedStateAccess` identifies only handle reads/writes; defensive codec-stage exceptions use a
+  separate `Unexpected` problem so callers are not sent to the wrong subsystem;
+- linear and tab storage keep separate keys and magic without changing either existing contract;
+- returned save, restore, and envelope problem lists are runtime-unmodifiable.
+
+## Final verification
+
+```text
+Focused tab envelope/storage API: 13/13
+
+./gradlew testDebugUnitTest --rerun-tasks lintDebug assembleDebug assembleDebugAndroidTest
+BUILD SUCCESSFUL
+
+JVM: 250 tests / 28 suites
+Failures: 0
+Errors: 0
+Skipped: 0
+```
+
+No emulator or screenshot is attached because this slice changes no UI and adds no Activity or
+ViewModel owner. A copied `SavedStateHandle` primitive proves the storage boundary only; lifecycle
+recreation, fallback/rewrite, revision reset, and transition reset belong to the next child of #26.
+
+Architecture review found no open P0–P2 issues. Test and external-consumer reviews each found one
+P2: exact adapter diagnostics were initially asserted only by type, and non-handle exceptions were
+mislabelled as saved-state access failures. Both findings were fixed before the final gate and sent
+back for focused re-review; both re-reviews returned clean with no open P0–P2 issues.


### PR DESCRIPTION
Closes #48

## What changed
- add a strict, separately versioned outer envelope for the complete ordered tab graph
- add internal one-key `SavedStateHandle` storage with an injected application `RouteCodec`
- preserve exact selected tab, histories, routes, entry IDs, and contextual typed failures
- keep linear and tab persistence isolated; no owner, fallback, transition, or UI policy in this slice

## Verification
- focused envelope/storage contracts: 13/13
- full JVM suite: 250 tests / 28 suites, 0 failures/errors/skips
- `lintDebug`, `assembleDebug`, `assembleDebugAndroidTest`: passed
- architecture, test, and external-consumer reviews: no open P0–P2 findings
- emulator not used; this slice has no UI/lifecycle owner